### PR TITLE
Add parser to split domain into subdomain, domain, and TLD

### DIFF
--- a/parsers/parse_domain.py
+++ b/parsers/parse_domain.py
@@ -1,0 +1,68 @@
+# Copyright 2019 Dan Nemec
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import urllib.parse
+import warnings
+
+try:
+    from publicsuffix2 import PublicSuffixList
+    psl = PublicSuffixList(idna=False)
+except ImportError:
+    warnings.warn("Unable to import the nodule 'publicsuffix2'. "
+                  "Will be unable to parse domain names.")
+    psl = None
+
+
+urlparse_edge = {
+    'color': {
+        'color': '#4d4d4d'
+    },
+    'title': 'URL Parsing Functions',
+    'label': 'u'
+}
+
+
+def run(unfurl, node):
+    if psl is None or node.data_type != 'netloc' or not isinstance(node.value, str):
+        return
+
+    full_domain = node.value
+    if full_domain.startswith('xn--') or '.xn--' in full_domain:
+        # punycoded domain
+        full_domain = full_domain.encode('utf8').decode('idna')
+    if '%' in full_domain:
+        # percent-encoded domain
+        full_domain = urllib.parse.unquote(full_domain)
+
+    domain = psl.get_sld(full_domain)
+    if domain is not None:
+        if len(domain) != len(full_domain):
+            subdomain = full_domain[:-len(domain)-1]
+            unfurl.add_to_queue(
+                data_type='url.subdomain', key='Subdomain', value=subdomain,
+                hover='This is the <b>sub-domain</b> part of the domain or '
+                      'netloc.',
+                parent_id=node.node_id, incoming_edge_config=urlparse_edge)
+        unfurl.add_to_queue(
+            data_type='url.domain', key='Domain Name', value=domain,
+            hover='This is the base, registerable, part of the domain or netloc',
+            parent_id=node.node_id, incoming_edge_config=urlparse_edge)
+        
+    tld = psl.get_tld(full_domain)
+    if tld is not None:
+        unfurl.add_to_queue(
+            data_type='url.tld', key='TLD', value=tld,
+            hover='This is the <b>Top Level Domain</b>, or TLD, for the domain '
+                  'or netloc',
+            parent_id=node.node_id, incoming_edge_config=urlparse_edge)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ flask
 flask_cors
 networkx
 protobuf
+publicsuffix2


### PR DESCRIPTION
This parser takes the 'netloc' node and splits it into three pieces:
* Subdomain (if available, e.g. `www`)
* Base domain (e.g. `google.com`)
* Top Level Domain (e.g. `com`)

I used the node's 'key' as a label to describe which part is which to users - I hope I'm not misusing that field.

The domain and TLD are calculated using the library [publicsuffix2](https://pypi.org/project/publicsuffix2/), which includes a bundled [suffix list](https://publicsuffix.org/) to properly handle domains like `google.co.uk`.

I also added support for internationalized domain names in the new nodes. For example, if you submit a URL like `https://www.食狮.com.cn` to the API python will parse it in percent-encoded form (`https://www.%E9%A3%9F%E7%8B%AE.com.cn`). I left the existing nodes alone but the new nodes will properly show `https://www.食狮.com.cn`. It also supports 'punycoded' domains like `www.xn--85x722f.com.cn` (equivalent to the others) and will decode to the UTF-8 characters.

Examples:

    https://scontent-atl3-1.cdninstagram.com/v/8245_168261091_n.jpg
![Decode scontent-atl3-1.cdninstagram.com](https://user-images.githubusercontent.com/136378/71504637-d7fdb300-283f-11ea-9170-35fa9e90e18d.png)

    https://%E9%A3%9F.www.%E9%A3%9F%E7%8B%AE.com.cn/hello/world/%E9%A3%9F
![Decode %E9%A3%9F.www.%E9%A3%9F%E7%8B%AE.com.cn](https://user-images.githubusercontent.com/136378/71504660-ee0b7380-283f-11ea-83ab-fd3c30742a99.png)

    https://www.xn--85x722f.com.cn
![Decode www.xn--85x722f.com.cn](https://user-images.githubusercontent.com/136378/71504689-08455180-2840-11ea-91db-f8bee4daa632.png)

Thanks! This is a very cool project.