### PR TITLE
Update Docker configuration and steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,9 @@ RUN apk update && apk add --no-cache git python3 && \
     git clone https://github.com/obsidianforensics/unfurl && \
     cd unfurl && \
     pip3 install -r requirements.txt
+
+COPY unfurl.ini /unfurl/unfurl.ini
+RUN sed -i 's/^host.*/host = 0.0.0.0/' /unfurl/unfurl.ini
+
 WORKDIR /unfurl
 ENTRYPOINT ["/usr/bin/python3", "unfurl_app.py"]

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ optional arguments:
 
 1. `git clone https://github.com/obsidianforensics/unfurl`
 1. `cd unfurl`
-1. Modify `unfurl.ini` with desired host and port, and `docker-compose.yaml` to match port defined in `unfurl.ini`.
 1. `docker-compose up -d`
 
 ## Testing 
@@ -82,6 +81,9 @@ optional arguments:
 1. All tests are run automatically on each PR by Travis CI. Tests need to pass before merging. 
 1. While not required, it is strongly encouraged to add tests that cover any new features in a PR. 
 1. To manually run all tests (units and integration): ``python -m unittest discover -s unfurl/tests``
+
+If using Docker as above, run: 
+``docker exec unfurl python -m unittest discover -s unfurl/tests``
 
 ## Legal Bit
 This is not an officially supported Google product.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,5 @@ services:
       dockerfile: Dockerfile
     # Match the port defined in unfurl.ini
     ports:
-      - "3000:3000"
-    volumes:
-      - ./unfurl.ini:/unfurl/unfurl.ini:ro
+      - "5000:5000"
     restart: unless-stopped


### PR DESCRIPTION
This PR aligns the Docker ports to the `unfurl.ini` (5000) and uses `COPY` instead of a volume mount, this makes it easier to run _off the bat_.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR

(Coming from SANS DFIR Summit 😃 Great talk 👏)