### PR TITLE
Add option to allow remote lookups (-l); disabled by default.

### DIFF
--- a/unfurl.ini
+++ b/unfurl.ini
@@ -1,6 +1,7 @@
 [UNFURL_APP]
 host = localhost
 port = 5000
+remote_lookups = false
 
 [API_KEYS]
 bitly =

--- a/unfurl/parsers/parse_hash.py
+++ b/unfurl/parsers/parse_hash.py
@@ -89,7 +89,7 @@ def run(unfurl, node):
         return
 
     if node.data_type.startswith('hash'):
-        if node.data_type == 'hash.md5':
+        if node.data_type == 'hash.md5' and unfurl.remote_lookups:
             hash_plaintext = nitrxgen_md5_lookup(node.value)
 
             if hash_plaintext:
@@ -99,7 +99,7 @@ def run(unfurl, node):
                     hover='Queried Nitrxgen database of MD5 hashes and found a matching plaintext value',
                     parent_id=node.node_id, incoming_edge_config=hash_lookup_edge)
 
-        if node.data_type in ('hash.md5', 'hash.sha-1', 'hash.sha-256'):
+        if node.data_type in ('hash.md5', 'hash.sha-1', 'hash.sha-256') and unfurl.remote_lookups:
             vt_results = virustotal_lookup(unfurl, node.value)
             if vt_results:
                 label_text = 'Hash found on VirusTotal'
@@ -153,19 +153,19 @@ def run(unfurl, node):
 
         if len(node.value) == 32:
             hash_name = 'MD5'
-            hash_hover = f'This is potentially a <b>{hash_name}</b> hash.'
+            hash_hover = f'This is potentially a <b>{hash_name}</b> hash <br>(based on length and character set).'
 
         if len(node.value) == 40:
             hash_name = 'SHA-1'
-            hash_hover = f'This is potentially a <b>{hash_name}</b> hash.'
+            hash_hover = f'This is potentially a <b>{hash_name}</b> hash <br>(based on length and character set).'
 
         if len(node.value) == 64:
             hash_name = 'SHA-256'
-            hash_hover = f'This is potentially a <b>{hash_name}</b> hash.'
+            hash_hover = f'This is potentially a <b>{hash_name}</b> hash <br>(based on length and character set).'
 
         if len(node.value) == 128:
             hash_name = 'SHA-512'
-            hash_hover = f'This is potentially a <b>{hash_name}</b> hash.'
+            hash_hover = f'This is potentially a <b>{hash_name}</b> hash <br>(based on length and character set).'
 
         if hash_name in ('MD5', 'SHA-1', 'SHA-256'):
             # Pass through the values of three common file hashes for further analysis; don't send on the

--- a/unfurl/parsers/parse_mac_addr.py
+++ b/unfurl/parsers/parse_mac_addr.py
@@ -44,7 +44,7 @@ def run(unfurl, node):
                 data_type='mac-address', key=None, value=pretty_mac, label=f'MAC address: {pretty_mac}',
                 parent_id=node.node_id, incoming_edge_config=uuid_edge)
 
-    elif node.data_type == 'mac-address' and unfurl.api_keys.get('macaddress_io'):
+    elif node.data_type == 'mac-address' and unfurl.api_keys.get('macaddress_io') and unfurl.remote_lookups:
         client = maclookup.ApiClient(unfurl.api_keys.get('macaddress_io'))
         vendor_lookup = client.get_vendor(node.value).decode('utf-8')
 

--- a/unfurl/parsers/parse_shortlink.py
+++ b/unfurl/parsers/parse_shortlink.py
@@ -50,71 +50,76 @@ def expand_url_via_redirect_header(base_url, shortcode):
 
 
 def run(unfurl, node):
+    if not node.data_type == 'url.path':
+        return
+
+    if not unfurl.remote_lookups:
+        return
+
     bitly_domains = ['bit.ly', 'bitly.com', 'j.mp']
-    if node.data_type == 'url.path':
-        if any(bitly_domain in unfurl.find_preceding_domain(node) for bitly_domain in bitly_domains):
-            expanded_info = expand_bitly_url(node.value[1:], unfurl.api_keys.get('bitly', os.environ.get('bitly')))
+    if any(bitly_domain in unfurl.find_preceding_domain(node) for bitly_domain in bitly_domains):
+        expanded_info = expand_bitly_url(node.value[1:], unfurl.api_keys.get('bitly', os.environ.get('bitly')))
 
-            if not expanded_info:
-                return
-
-            node.hover = 'Bitly Short Links can be expanded via the Bitly API to show the ' \
-                         '"long" URL and the creation time of the short-link.' \
-                         '<a href="https://dev.bitly.com/v4/#operation/expandBitlink" ' \
-                         'target="_blank">[ref]</a>'
-
-            if expanded_info['created_at'].endswith('+0000'):
-                expanded_info['created_at'] = expanded_info['created_at'][:-5]
-
-            if expanded_info['created_at'][10] == 'T':
-                expanded_info['created_at'] = f'{expanded_info["created_at"][:10]} {expanded_info["created_at"][11:]}'
-
-            unfurl.add_to_queue(
-                data_type='description', key=None, value=expanded_info['created_at'],
-                label=f'Creation Time:\n{expanded_info["created_at"]}',
-                hover='Short-link creation time, retrieved from Bitly API',
-                parent_id=node.node_id, incoming_edge_config=shortlink_edge)
-
-            unfurl.add_to_queue(
-                data_type='url', key=None, value=expanded_info['long_url'],
-                label=f'Expanded URL: {expanded_info["long_url"]}', hover='Expanded URL, retrieved from Bitly API',
-                parent_id=node.node_id, incoming_edge_config=shortlink_edge)
-
+        if not expanded_info:
             return
 
-        redirect_expands = [
-            {'domain': 'bit.do', 'base_url': 'https://bit.do/'},
-            {'domain': 'buff.ly', 'base_url': 'https://buff.ly/'},
-            {'domain': 'cutt.ly', 'base_url': 'https://cutt.ly/'},
-            {'domain': 'db.tt', 'base_url': 'https://db.tt/'},
-            {'domain': 'dlvr.it', 'base_url': 'https://dlvr.it/'},
-            {'domain': 'fb.me', 'base_url': 'https://fb.me/'},
-            {'domain': 'goo.gl', 'base_url': 'https://goo.gl/'},
-            {'domain': 'ift.tt', 'base_url': 'https://ift.tt/'},
-            {'domain': 'is.gd', 'base_url': 'https://is.gd/'},
-            {'domain': 'lc.chat', 'base_url': 'https://lc.chat/'},
-            {'domain': 'lnkd.in', 'base_url': 'https://www.linkedin.com/slink?code='},
-            {'domain': 'nyti.ms', 'base_url': 'https://nyti.ms/'},
-            {'domain': 'ow.ly', 'base_url': 'http://ow.ly/'},
-            {'domain': 'reut.rs', 'base_url': 'https://reut.rs/'},
-            {'domain': 'sansurl.com', 'base_url': 'https://sansurl.com/'},
-            {'domain': 'snip.ly', 'base_url': 'https://snip.ly/'},
-            {'domain': 't.co', 'base_url': 'https://t.co/'},
-            {'domain': 't.ly', 'base_url': 'https://t.ly/'},
-            {'domain': 'tr.im', 'base_url': 'https://tr.im/'},
-            {'domain': 'trib.al', 'base_url': 'https://trib.al/'},
-            {'domain': 'tinyurl.com', 'base_url': 'https://tinyurl.com/'},
-            {'domain': 'urlwee.com', 'base_url': 'https://urlwee.com/'},
-            {'domain': 'urlzs.com', 'base_url': 'https://urlzs.com/'},
-            {'domain': 'x.co', 'base_url': 'https://x.co/'},
-        ]
+        node.hover = 'Bitly Short Links can be expanded via the Bitly API to show the ' \
+                     '"long" URL and the creation time of the short-link.' \
+                     '<a href="https://dev.bitly.com/v4/#operation/expandBitlink" ' \
+                     'target="_blank">[ref]</a>'
 
-        for redirect_expand in redirect_expands:
-            if redirect_expand['domain'] == unfurl.find_preceding_domain(node):
-                expanded_url = expand_url_via_redirect_header(redirect_expand['base_url'], node.value[1:])
-                if expanded_url:
-                    unfurl.add_to_queue(
-                        data_type='url', key=None, value=expanded_url,
-                        label=f'Expanded URL: {expanded_url}',
-                        hover=f'Expanded URL, retrieved from {redirect_expand["domain"]} via "Location" header',
-                        parent_id=node.node_id, incoming_edge_config=shortlink_edge)
+        if expanded_info['created_at'].endswith('+0000'):
+            expanded_info['created_at'] = expanded_info['created_at'][:-5]
+
+        if expanded_info['created_at'][10] == 'T':
+            expanded_info['created_at'] = f'{expanded_info["created_at"][:10]} {expanded_info["created_at"][11:]}'
+
+        unfurl.add_to_queue(
+            data_type='description', key=None, value=expanded_info['created_at'],
+            label=f'Creation Time:\n{expanded_info["created_at"]}',
+            hover='Short-link creation time, retrieved from Bitly API',
+            parent_id=node.node_id, incoming_edge_config=shortlink_edge)
+
+        unfurl.add_to_queue(
+            data_type='url', key=None, value=expanded_info['long_url'],
+            label=f'Expanded URL: {expanded_info["long_url"]}', hover='Expanded URL, retrieved from Bitly API',
+            parent_id=node.node_id, incoming_edge_config=shortlink_edge)
+
+        return
+
+    redirect_expands = [
+        {'domain': 'bit.do', 'base_url': 'https://bit.do/'},
+        {'domain': 'buff.ly', 'base_url': 'https://buff.ly/'},
+        {'domain': 'cutt.ly', 'base_url': 'https://cutt.ly/'},
+        {'domain': 'db.tt', 'base_url': 'https://db.tt/'},
+        {'domain': 'dlvr.it', 'base_url': 'https://dlvr.it/'},
+        {'domain': 'fb.me', 'base_url': 'https://fb.me/'},
+        {'domain': 'goo.gl', 'base_url': 'https://goo.gl/'},
+        {'domain': 'ift.tt', 'base_url': 'https://ift.tt/'},
+        {'domain': 'is.gd', 'base_url': 'https://is.gd/'},
+        {'domain': 'lc.chat', 'base_url': 'https://lc.chat/'},
+        {'domain': 'lnkd.in', 'base_url': 'https://www.linkedin.com/slink?code='},
+        {'domain': 'nyti.ms', 'base_url': 'https://nyti.ms/'},
+        {'domain': 'ow.ly', 'base_url': 'http://ow.ly/'},
+        {'domain': 'reut.rs', 'base_url': 'https://reut.rs/'},
+        {'domain': 'sansurl.com', 'base_url': 'https://sansurl.com/'},
+        {'domain': 'snip.ly', 'base_url': 'https://snip.ly/'},
+        {'domain': 't.co', 'base_url': 'https://t.co/'},
+        {'domain': 't.ly', 'base_url': 'https://t.ly/'},
+        {'domain': 'tr.im', 'base_url': 'https://tr.im/'},
+        {'domain': 'trib.al', 'base_url': 'https://trib.al/'},
+        {'domain': 'tinyurl.com', 'base_url': 'https://tinyurl.com/'},
+        {'domain': 'urlwee.com', 'base_url': 'https://urlwee.com/'},
+        {'domain': 'urlzs.com', 'base_url': 'https://urlzs.com/'},
+        {'domain': 'x.co', 'base_url': 'https://x.co/'},
+    ]
+
+    for redirect_expand in redirect_expands:
+        if redirect_expand['domain'] == unfurl.find_preceding_domain(node):
+            expanded_url = expand_url_via_redirect_header(redirect_expand['base_url'], node.value[1:])
+            if expanded_url:
+                unfurl.add_to_queue(
+                    data_type='url', key=None, value=expanded_url,
+                    label=f'Expanded URL: {expanded_url}',
+                    hover=f'Expanded URL, retrieved from {redirect_expand["domain"]} via "Location" header',
+                    parent_id=node.node_id, incoming_edge_config=shortlink_edge)

--- a/unfurl/tests/unit/test_shortlink.py
+++ b/unfurl/tests/unit/test_shortlink.py
@@ -7,7 +7,7 @@ class TestBitly(unittest.TestCase):
     def test_linkedin_shortlink(self):
         """ Test a LinkedIn shortlink; these work a little different than the rest"""
         
-        test = Unfurl()
+        test = Unfurl(remote_lookups=True)
         test.add_to_queue(data_type='url', key=None, value='https://lnkd.in/fDJnJ64')
         test.parse_queue()
 
@@ -26,7 +26,7 @@ class TestBitly(unittest.TestCase):
     def test_twitter_shortlink(self):
         """ Test a Twitter shortlink; these use 301 redirects like most shortlinks"""
 
-        test = Unfurl()
+        test = Unfurl(remote_lookups=True)
         test.add_to_queue(data_type='url', key=None, value='https://t.co/g6VWYYwY12')
         test.parse_queue()
 
@@ -41,6 +41,17 @@ class TestBitly(unittest.TestCase):
         # is processing finished empty
         self.assertTrue(test.queue.empty())
         self.assertEqual(len(test.edges), 0)
+
+    def test_no_lookups(self):
+        """ Test a shortlink with remote lookups disabled"""
+
+        test = Unfurl()
+        test.add_to_queue(data_type='url', key=None, value='https://t.co/g6VWYYwY12')
+        test.parse_queue()
+
+        # test number of nodes
+        self.assertEqual(len(test.nodes.keys()), 6)
+        self.assertEqual(test.total_nodes, 6)
 
 
 if __name__ == '__main__':

--- a/unfurl_app.py
+++ b/unfurl_app.py
@@ -28,10 +28,16 @@ if config.has_section('UNFURL_APP'):
     unfurl_host = config['UNFURL_APP'].get('host')
     unfurl_port = config['UNFURL_APP'].get('port')
     unfurl_debug = config['UNFURL_APP'].get('debug')
+    try:
+        remote_lookups = config['UNFURL_APP'].getboolean('remote_lookups')
+    # If we can't interpret it as a boolean, fail "safe" to not allowing lookups
+    except ValueError:
+        remote_lookups = False
 
 
 if __name__ == '__main__':
     core.UnfurlApp(
         unfurl_debug=unfurl_debug,
         unfurl_host=unfurl_host,
-        unfurl_port=unfurl_port)
+        unfurl_port=unfurl_port,
+        remote_lookups=remote_lookups)

--- a/unfurl_cli.py
+++ b/unfurl_cli.py
@@ -34,6 +34,8 @@ def main():
     parser.add_argument(
         '-f', '--filter', help='only output lines that match this filter.')
     parser.add_argument(
+        '-l', '--lookups', help='allow remote lookups to enhance results.', action='store_true')
+    parser.add_argument(
         '-o', '--output',
         help='file to save output (as CSV) to. if omitted, output is sent to '
              'stdout (typically this means displayed in the console).')


### PR DESCRIPTION
At the beginning, Unfurl was strictly using data encoded inside the URL itself, but it has slowly evolved past that and I've started adding more remote lookups to Unfurl. I still want to allow the user to control remote lookups (for OpSec and other considerations), so I'm adding an option for it  - with remote lookups disabled by default.
