### PR TITLE
fix issue#156

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flask
+flask==2.1.3
 flask-restx
 flask_cors
 maclookup
@@ -11,3 +11,4 @@ Requests
 setuptools
 torf
 ulid-py
+Werkzeug==2.1.2


### PR DESCRIPTION
The new flask version 2.2.0 released on 2022-08-02 breaks unfurl. See issue #156 for details.
 
Pinning flask version to 2.1.3. And adding the Werkzeug package pinend to 2.1.2 in the requirements.txt file fixes the issue short-term.

Fixes #156 

- [X] Tests pass