### PR TITLE
update workflow runner distro

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@master
     - name: Set up Python 3.9


### PR DESCRIPTION
ubuntu-18.04 workflow runners are deprecated since end of 2022. Updating to ubuntu-22.04 should be no problem here.