### PR TITLE
Add parsing of IP addresses in hostname

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "dfir-unfurl"
 authors = [{name = "Ryan Benson", email = "ryan@dfir.blog"}]
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 classifiers = [
     "License :: OSI Approved :: Apache Software License",

--- a/unfurl/parsers/__init__.py
+++ b/unfurl/parsers/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
     "parse_duckduckgo",
     "parse_google",
     "parse_hash",
+    "parse_ip",
     "parse_json",
     "parse_jwt",
     "parse_ksuid",

--- a/unfurl/parsers/parse_domain.py
+++ b/unfurl/parsers/parse_domain.py
@@ -15,6 +15,8 @@
 import urllib.parse
 import warnings
 
+from unfurl import utils
+
 try:
     from publicsuffix2 import PublicSuffixList
     psl = PublicSuffixList(idna=False)
@@ -51,7 +53,10 @@ def run(unfurl, node):
                 data_type='descriptor', key=None, value=cleaned_node_name, hover=cleaned_node_hover,
                 parent_id=node.node_id, incoming_edge_config=urlparse_edge)
 
-    if psl is None or node.data_type != 'url.hostname' or not isinstance(node.value, str):
+    if (psl is None
+            or node.data_type != 'url.hostname'
+            or not isinstance(node.value, str)
+            or utils.parse_ip_address(node.value)):
         return
 
     full_domain = node.value

--- a/unfurl/parsers/parse_ip.py
+++ b/unfurl/parsers/parse_ip.py
@@ -41,6 +41,6 @@ def run(unfurl, node):
             return
 
         unfurl.add_to_queue(
-            data_type='ip', key=None, value=parsed_ip,
+            data_type='ip', key=None, value=str(parsed_ip),
             hover=hover,
             parent_id=node.node_id, incoming_edge_config=urlparse_edge)

--- a/unfurl/parsers/parse_ip.py
+++ b/unfurl/parsers/parse_ip.py
@@ -1,0 +1,46 @@
+# Copyright 2025 Ryan Benson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ipaddress
+import re
+
+from unfurl import utils
+
+urlparse_edge = {
+    'color': {
+        'color': '#6734eb'
+    },
+    'title': 'URL Parsing Functions',
+    'label': 'IP'
+}
+
+
+def run(unfurl, node):
+
+    if node.data_type == 'url.hostname':
+        parsed_ip = utils.parse_ip_address(node.value)
+
+        if parsed_ip and re.fullmatch(utils.digits_re, node.value):
+            hover = 'Converted to IP address from an integer representation'
+        elif parsed_ip and re.fullmatch(r'0x[A-F0-9]{8}', node.value, flags=re.IGNORECASE):
+            hover = 'Converted to IP address from a hex representation'
+        elif parsed_ip and re.fullmatch(utils.octal_ip_re, node.value):
+            hover = 'Converted to IP address from an octal representation'
+        else:
+            return
+
+        unfurl.add_to_queue(
+            data_type='ip', key=None, value=parsed_ip,
+            hover=hover,
+            parent_id=node.node_id, incoming_edge_config=urlparse_edge)

--- a/unfurl/tests/unit/test_ip.py
+++ b/unfurl/tests/unit/test_ip.py
@@ -106,14 +106,14 @@ class TestIp(unittest.TestCase):
         test.parse_queue()
 
         # check the number of nodes
-        self.assertEqual(6, len(test.nodes.keys()))
-        self.assertEqual(6, test.total_nodes)
+        self.assertEqual(5, len(test.nodes.keys()))
+        self.assertEqual(5, test.total_nodes)
 
         # confirm the scheme is parsed
         self.assertIn('https', test.nodes[2].label)
 
         # confirm the IP is parsed
-        self.assertEqual('216.58.199.78', test.nodes[6].label)
+        self.assertEqual('216.58.199.78', test.nodes[5].label)
 
         # confirm the path is parsed
         self.assertIn('path', test.nodes[4].hover)

--- a/unfurl/tests/unit/test_ip.py
+++ b/unfurl/tests/unit/test_ip.py
@@ -1,0 +1,123 @@
+from unfurl.core import Unfurl
+import unittest
+
+
+class TestIp(unittest.TestCase):
+
+    def test_ip(self):
+        """ Test a generic IP with a scheme and path"""
+
+        test = Unfurl()
+        test.add_to_queue(
+            data_type='url', key=None,
+            value='https://216.58.199.78/test')
+        test.parse_queue()
+
+        # check the number of nodes
+        self.assertEqual(4, len(test.nodes.keys()))
+        self.assertEqual(4, test.total_nodes)
+
+        # confirm the scheme is parsed
+        self.assertIn('https', test.nodes[2].label)
+
+        # confirm the IP is parsed
+        self.assertEqual('216.58.199.78', test.nodes[3].label)
+
+        # confirm the path is parsed
+        self.assertIn('path', test.nodes[4].hover)
+
+
+    def test_almost_ip(self):
+        """ Test a domain that looks almost like an IP, with a scheme and path"""
+
+        test = Unfurl()
+        test.add_to_queue(
+            data_type='url', key=None,
+            value='https://216.58.199.com/test')
+        test.parse_queue()
+
+        # check the number of nodes
+        self.assertEqual(7, len(test.nodes.keys()))
+        self.assertEqual(7, test.total_nodes)
+
+        # confirm the scheme is parsed
+        self.assertIn('https', test.nodes[2].label)
+
+        # confirm the domain is parsed
+        self.assertEqual('Domain Name: 199.com', test.nodes[6].label)
+
+        # confirm the path is parsed
+        self.assertIn('path', test.nodes[4].hover)
+
+
+    def test_int_ip(self):
+        """ Test an IP represented as an integer, with a scheme and path"""
+
+        test = Unfurl()
+        test.add_to_queue(
+            data_type='url', key=None,
+            value='https://3627730766/test')
+        test.parse_queue()
+
+        # check the number of nodes
+        self.assertEqual(5, len(test.nodes.keys()))
+        self.assertEqual(5, test.total_nodes)
+
+        # confirm the scheme is parsed
+        self.assertIn('https', test.nodes[2].label)
+
+        # confirm the IP is parsed
+        self.assertEqual('216.58.199.78', test.nodes[5].label)
+
+        # confirm the path is parsed
+        self.assertIn('path', test.nodes[4].hover)
+
+
+    def test_hex_ip(self):
+        """ Test an IP represented as hex, with a scheme and path"""
+
+        test = Unfurl()
+        test.add_to_queue(
+            data_type='url', key=None,
+            value='https://0xD83AC74E/test')
+        test.parse_queue()
+
+        # check the number of nodes
+        self.assertEqual(6, len(test.nodes.keys()))
+        self.assertEqual(6, test.total_nodes)
+
+        # confirm the scheme is parsed
+        self.assertIn('https', test.nodes[2].label)
+
+        # confirm the IP is parsed
+        self.assertEqual('216.58.199.78', test.nodes[6].label)
+
+        # confirm the path is parsed
+        self.assertIn('path', test.nodes[4].hover)
+
+
+    def test_octal_ip(self):
+        """ Test an IP represented as octal, with a scheme and path"""
+
+        test = Unfurl()
+        test.add_to_queue(
+            data_type='url', key=None,
+            value='https://0330.0072.0307.0116/test')
+        test.parse_queue()
+
+        # check the number of nodes
+        self.assertEqual(6, len(test.nodes.keys()))
+        self.assertEqual(6, test.total_nodes)
+
+        # confirm the scheme is parsed
+        self.assertIn('https', test.nodes[2].label)
+
+        # confirm the IP is parsed
+        self.assertEqual('216.58.199.78', test.nodes[6].label)
+
+        # confirm the path is parsed
+        self.assertIn('path', test.nodes[4].hover)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unfurl/utils.py
+++ b/unfurl/utils.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import ipaddress
 import re
 import textwrap
 from typing import Union
@@ -29,6 +30,23 @@ letters_and_slash_re = re.compile(r'[A-Z/]+', flags=re.IGNORECASE)
 float_re = re.compile(r'\d+\.\d+')
 mac_addr_re = re.compile(r'(?P<mac_addr>[0-9A-Fa-f]{12}|([0-9A-Fa-f]:){6})')
 cisco_7_re = re.compile(r'\d{2}[A-F0-9]{4,}', re.IGNORECASE)
+octal_ip_re = re.compile(r'(0[0-7]{3})\.(0[0-7]{3})\.(0[0-7]{3})\.(0[0-7]{3})')
+
+
+def parse_ip_address(potential_ip):
+    if re.fullmatch(digits_re, potential_ip):
+        potential_ip = int(potential_ip)
+    elif re.fullmatch(r'0x[A-F0-9]{8}', potential_ip, flags=re.IGNORECASE):
+        potential_ip = int(potential_ip, base=16)
+    elif re.fullmatch(octal_ip_re, potential_ip):
+        m = re.fullmatch(octal_ip_re, potential_ip)
+        potential_ip = f"{int(m.group(1), 8)}.{int(m.group(2), 8)}.{int(m.group(3), 8)}.{int(m.group(4), 8)}"
+    try:
+        parsed_ip = ipaddress.ip_address(potential_ip)
+    except ValueError:
+        parsed_ip = None
+
+    return parsed_ip
 
 
 def wrap_hover_text(hover_text: Union[str, None]) -> Union[str, None]:


### PR DESCRIPTION
Adds recognition of IPs in the hostname position of a URL (and stops IPs from being erroneously parsed as domains) - #211 
Adds parsing of different IP encodings - integer, octal, and hex - #98 

- [x] Tests pass
