### PR TITLE
Switch MAC address vendor lookups to use `netaddr`; previous package …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 bbpb >= 1.4.1
 dnslib < 1
-mac-vendor-lookup>=0.1.12
-networkx==3.*
+netaddr >= 1.3.0
+networkx == 3.*
 protobuf >= 4.0, < 6.0
 publicsuffix2
 pycountry > 24
-pymispwarninglists>=1.6.1
+pymispwarninglists >= 1.6.1
 requests >= 2.32
 torf > 4
 ulid-py > 1

--- a/unfurl/parsers/parse_mac_addr.py
+++ b/unfurl/parsers/parse_mac_addr.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mac_vendor_lookup
+import netaddr
 from unfurl import utils
+
+import logging
+log = logging.getLogger(__name__)
 
 uuid_edge = {
     'color': {
@@ -26,7 +29,12 @@ uuid_edge = {
 
 def run(unfurl, node):
     if node.data_type == 'mac-address':
-        vendor_lookup = mac_vendor_lookup.MacLookup().lookup(node.value)
+        try:
+            vendor_lookup = netaddr.EUI(node.value).oui.registration().org
+        except Exception as e:
+            log.exception(f'Exception while parsing MAC address: {e}')
+            return
+
         if vendor_lookup:
             unfurl.add_to_queue(
                 data_type="mac-address.vendor", key=None, value=vendor_lookup, label=f'Vendor: {vendor_lookup}',

--- a/unfurl/tests/unit/test_mac_addr.py
+++ b/unfurl/tests/unit/test_mac_addr.py
@@ -1,0 +1,68 @@
+from unfurl.core import Unfurl
+import unittest
+
+
+class TestMacAddr(unittest.TestCase):
+
+    def test_mac_addr(self):
+        """ Test a MAC address with colons"""
+
+        test = Unfurl()
+        test.add_to_queue(
+            data_type='url', key=None,
+            value='00:B0:D0:63:C2:26')
+        test.parse_queue()
+
+        # check the number of nodes
+        self.assertEqual(3, len(test.nodes.keys()))
+        self.assertEqual(3, test.total_nodes)
+
+        # confirm the scheme is parsed
+        self.assertIn('MAC address', test.nodes[2].label)
+
+        # confirm the vendor is parsed
+        self.assertIn('Dell', test.nodes[3].label)
+
+
+    def test_mac_addr_bare(self):
+        """ Test a bare MAC address (no delimiters)"""
+
+        test = Unfurl()
+        test.add_to_queue(
+            data_type='url', key=None,
+            value='00B0D063C226')
+        test.parse_queue()
+
+        # check the number of nodes
+        self.assertEqual(3, len(test.nodes.keys()))
+        self.assertEqual(3, test.total_nodes)
+
+        # confirm the scheme is parsed
+        self.assertIn('MAC address', test.nodes[2].label)
+
+        # confirm the vendor is parsed
+        self.assertIn('Dell', test.nodes[3].label)
+
+
+    def test_mac_addr_dashes(self):
+        """ Test a MAC address with dashes"""
+
+        test = Unfurl()
+        test.add_to_queue(
+            data_type='url', key=None,
+            value='00-B0-D0-63-C2-26')
+        test.parse_queue()
+
+        # check the number of nodes
+        self.assertEqual(3, len(test.nodes.keys()))
+        self.assertEqual(3, test.total_nodes)
+
+        # confirm the scheme is parsed
+        self.assertIn('MAC address', test.nodes[2].label)
+
+        # confirm the vendor is parsed
+        self.assertIn('Dell', test.nodes[3].label)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unfurl/utils.py
+++ b/unfurl/utils.py
@@ -28,7 +28,7 @@ letters_re = re.compile(r'[A-Z]+', flags=re.IGNORECASE)
 digits_and_slash_re = re.compile(r'[0-9/]+')
 letters_and_slash_re = re.compile(r'[A-Z/]+', flags=re.IGNORECASE)
 float_re = re.compile(r'\d+\.\d+')
-mac_addr_re = re.compile(r'(?P<mac_addr>[0-9A-Fa-f]{12}|([0-9A-Fa-f]:){6})')
+mac_addr_re = re.compile(r'(?P<mac_addr>[0-9A-Fa-f]{12}|([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2})')
 cisco_7_re = re.compile(r'\d{2}[A-F0-9]{4,}', re.IGNORECASE)
 octal_ip_re = re.compile(r'(0[0-7]{3})\.(0[0-7]{3})\.(0[0-7]{3})\.(0[0-7]{3})')
 


### PR DESCRIPTION
…was often throwing exceptions while parsing. Update MAC Address regex to catch more common formats, and add tests.

- [ ] Tests pass
