### PR TITLE
Add Facebook URL parser with path, query, and hover `site_defs` rules…

### DIFF
--- a/unfurl/parsers/__init__.py
+++ b/unfurl/parsers/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     "parse_dns",
     "parse_domain",
     "parse_dropbox",
+    "parse_facebook",
     "parse_duckduckgo",
     "parse_google",
     "parse_hash",

--- a/unfurl/parsers/parse_facebook.py
+++ b/unfurl/parsers/parse_facebook.py
@@ -1,0 +1,244 @@
+# Copyright 2026 Ryan Benson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import json
+import logging
+import urllib.request
+
+log = logging.getLogger(__name__)
+
+# Modern Facebook Click IDs (fbclid) use a binary serialization format:
+#   [2-char header][base64url-encoded payload][optional _aem_ suffix]
+#
+# Headers (case-insensitive in practice; hypothesized meanings based on
+# observed URL contexts — not officially documented by Meta):
+#   'Iw' = likely outbound click (user clicked an external link)
+#   'PA' = likely page/ad impression tracking
+#
+# Payload contains known field names as literal ASCII strings, each followed
+# by a length byte and value. Values may be ASCII strings or binary.
+# The parser scans for known field names rather than walking sequentially,
+# as binary values can contain bytes >= 0x20 that disrupt sequential parsing.
+#
+# Known fields (reverse-engineered names; not documented by Meta):
+#   extn    = extension type (usually 'aem' = Aggregated Event Measurement)
+#   brid    = browser ID (links clicks from same browser session)
+#   clck    = click tracking (alternative to extn in some variants)
+#   srtc    = source tracking code (often wraps app_id as a nested key)
+#   app_id  = Facebook App ID (resolvable via Graph API)
+#   adid    = advertisement ID (often a binary value)
+#
+# Optional '_aem_' suffix: 16-byte hash for privacy-preserving ad attribution
+
+facebook_edge = {
+    'color': {
+        'color': '#1877F2'
+    },
+    'title': 'Facebook Click ID',
+    'label': 'f'
+}
+
+KNOWN_FIELDS = {
+    'extn': ('Extension Type', 'The tracking extension type. '
+             '"aem" = Aggregated Event Measurement, Facebook\'s privacy-preserving '
+             'ad attribution system.'),
+    'brid': ('Browser ID', 'A browser identifier that links '
+             'multiple clicks from the same browser session. Similar to Meta\'s '
+             'documented _fbp "browser ID" cookie. (Reverse-engineered name, '
+             'not officially documented by Meta.)'),
+    'app_id': ('App ID', 'The Facebook application ID that generated or is '
+               'tracking this link click.'),
+    'adid': ('Ad ID', 'An advertisement identifier, present when the '
+             'click originated from a Facebook ad.'),
+    'srtc': ('Source Tracking', 'A source tracking code for the click.'),
+    'clck': ('Click Tracking', 'A click tracking identifier. '
+             'Found in IwY2-prefix fbclids as an alternative to extn.'),
+}
+
+# Old-format fbclids (IwAR...) are opaque and can't be decoded
+OLD_FORMAT_PREFIXES = ('IwAR', 'iwar')
+
+# Known Facebook App IDs — resolved via Graph API (April 2026).
+# These are Meta's own internal app identifiers and are stable.
+KNOWN_APP_IDS = {
+    '2220391788200892': 'WWW (Comet)',
+    '256281040558': 'WWW',
+    '350685531728': 'Facebook for Android',
+    '6628568379': 'Facebook for iPhone',
+    '124024574287414': 'Instagram',
+    '567067343352427': 'Instagram for Android (Analytics Only)',
+    '905593853150754': 'Instagram Carbon',
+    '275254692598279': 'Facebook Lite',
+    '409962623085609': 'Facebook Lite for Web (WebLite)',
+    '173847642670370': 'Facebook for iPad',
+    '437626316973788': 'Messenger for iOS',
+    '514771569228061': 'BizWeb',
+    '119211728144504': 'Power editor',
+    '412378670482': 'Msite',
+    '436761779744620': 'Business Manager',
+    '2094176354154603': 'Ads Events Manager',
+}
+
+
+def lookup_app_id(app_id, remote=False):
+    """Resolve a Facebook App ID to its name.
+
+    Uses a built-in table of known IDs first, then falls back to
+    the Graph API for unknown IDs (only if remote=True).
+    """
+    # Check offline table first
+    if app_id in KNOWN_APP_IDS:
+        return KNOWN_APP_IDS[app_id]
+
+    if not remote:
+        return None
+
+    # Fall back to Graph API
+    try:
+        url = f'https://graph.facebook.com/{app_id}'
+        req = urllib.request.Request(url, headers={'User-Agent': 'unfurl/1.0'})
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = json.loads(resp.read())
+            return data.get('name')
+    except Exception as e:
+        log.debug(f'Failed to resolve Facebook App ID {app_id}: {e}')
+        return None
+
+
+def parse_fbclid(unfurl, node):
+    """Parse a modern Facebook Click ID into its component fields."""
+    fbclid = str(node.value)
+
+    # Old format is opaque
+    if fbclid.startswith(OLD_FORMAT_PREFIXES):
+        return
+
+    header = fbclid[:2]
+    rest = fbclid[2:]
+
+    # Handle _aem_ suffix
+    aem_hash = None
+    if '_aem_' in rest:
+        rest, aem_suffix = rest.split('_aem_', 1)
+        try:
+            padded = aem_suffix + '=' * ((4 - len(aem_suffix) % 4) % 4)
+            aem_hash = base64.urlsafe_b64decode(padded).hex()
+        except Exception:
+            aem_hash = aem_suffix
+
+    padded = rest + '=' * ((4 - len(rest) % 4) % 4)
+    try:
+        data = base64.urlsafe_b64decode(padded)
+    except Exception:
+        return
+
+    # Parse the binary TLV payload.
+    # Format: repeated [ascii_key][length_byte][value_bytes]
+    # Known field names appear as literal ASCII in the payload. Rather than
+    # walking byte-by-byte (which breaks when binary values contain bytes
+    # >= 0x20 that look like ASCII keys), scan for known field names directly.
+    fields_found = {}
+    data_str = data.decode('latin-1')  # safe 1:1 byte mapping
+
+    for field_key in KNOWN_FIELDS:
+        pos = 0
+        while True:
+            pos = data_str.find(field_key, pos)
+            if pos == -1:
+                break
+
+            val_start = pos + len(field_key)
+            if val_start >= len(data):
+                break
+
+            val_len = data[val_start]
+            val_offset = val_start + 1
+
+            if val_len == 0 or val_offset + val_len > len(data):
+                pos += 1
+                continue
+
+            value_bytes = data[val_offset:val_offset + val_len]
+
+            # Check if value is printable ASCII
+            is_ascii = all(0x20 <= b < 0x7f for b in value_bytes)
+
+            if is_ascii:
+                value = value_bytes.decode('ascii')
+
+                # If the value is itself a known field name, it indicates nesting:
+                # e.g. srtc -> app_id -> "2203917882008922"
+                if value in KNOWN_FIELDS:
+                    nested_key = value
+                    ni = val_offset + val_len
+                    # Skip any empty key (bytes >= 0x20 before length byte)
+                    while ni < len(data) and data[ni] >= 0x20:
+                        ni += 1
+                    if ni < len(data):
+                        nval_len = data[ni]
+                        ni += 1
+                        if nval_len > 0 and ni + nval_len <= len(data):
+                            nval_bytes = data[ni:ni + nval_len]
+                            if all(0x20 <= b < 0x7f for b in nval_bytes):
+                                fields_found[nested_key] = nval_bytes.decode('ascii')
+                else:
+                    fields_found[field_key] = value
+            else:
+                # Binary value — store as hex for fields like adid
+                fields_found[field_key] = value_bytes.hex()
+
+            pos = val_offset + val_len
+
+    if not fields_found and not aem_hash:
+        return
+
+    node.hover = (
+        'Facebook Click ID (fbclid) containing tracking fields. '
+        f'Header "{header}" indicates '
+        f'{"an outbound link click" if header == "Iw" else "a page/ad impression"}.'
+    )
+
+    for field_key, value in fields_found.items():
+        label_name, hover_text = KNOWN_FIELDS[field_key]
+
+        # For app_id, resolve to a human-readable name
+        if field_key == 'app_id':
+            app_name = lookup_app_id(value, remote=unfurl.remote_lookups)
+            if app_name:
+                label_name = 'App'
+                value = f'{app_name} ({value})'
+
+        unfurl.add_to_queue(
+            data_type=f'facebook.fbclid.{field_key}',
+            key=None, value=value,
+            label=f'{label_name}: {value}',
+            hover=hover_text,
+            parent_id=node.node_id,
+            incoming_edge_config=facebook_edge)
+
+    if aem_hash:
+        unfurl.add_to_queue(
+            data_type='facebook.fbclid.aem_hash',
+            key=None, value=aem_hash,
+            label=f'AEM Hash: {aem_hash[:16]}...',
+            hover='Aggregated Event Measurement hash. A 16-byte value used for '
+                  'privacy-preserving ad attribution (related to Apple ATT/SKAdNetwork).',
+            parent_id=node.node_id,
+            incoming_edge_config=facebook_edge)
+
+
+def run(unfurl, node):
+    if node.data_type == 'url.query.pair' and node.key == 'fbclid':
+        parse_fbclid(unfurl, node)

--- a/unfurl/parsers/parse_site_defs.py
+++ b/unfurl/parsers/parse_site_defs.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import fnmatch
 import logging
 import re
 from pathlib import Path
@@ -118,18 +119,23 @@ def _check_path_rule(unfurl, node, rule, site_def):
         if node.key != rule['position']:
             return False
 
-        # Check exclude_values: skip if this node's value is in the exclusion list
-        if node.value in rule.get('exclude_values', []):
-            return False
+        # Check exclude_values: skip if this node's value matches the exclusion list.
+        # Supports wildcards (e.g., '*.php') via fnmatch.
+        for pattern in rule.get('exclude_values', []):
+            if fnmatch.fnmatch(node.value, pattern):
+                return False
 
-        # Check exclude_sibling: skip if a sibling segment matches any excluded value
+        # Check exclude_sibling: skip if a sibling segment matches any excluded value.
+        # Supports wildcards (e.g., '*.php') via fnmatch.
         exclude_sib = rule.get('exclude_sibling')
         if exclude_sib:
-            for val in exclude_sib.get('values', []):
-                if unfurl.check_sibling_nodes(
-                        node, data_type='url.path.segment',
-                        key=int(exclude_sib['key']), value=str(val)):
-                    return False
+            sibling = unfurl.check_sibling_nodes(
+                node, data_type='url.path.segment',
+                key=int(exclude_sib['key']), return_node=True)
+            if sibling:
+                for pattern in exclude_sib.get('values', []):
+                    if fnmatch.fnmatch(str(sibling.value), pattern):
+                        return False
 
         # Check match constraints
         for seg_key, seg_value in match.items():
@@ -149,6 +155,12 @@ def _check_query_rule(unfurl, node, rule, site_def):
         return False
 
     apply = rule['apply']
+
+    # hover_only: just set hover text on the existing node, don't create a child
+    if apply.get('hover_only'):
+        node.hover = apply.get('hover', '')
+        return True
+
     edge_config = site_def['_edge_config']
     label = _format_label(apply.get('label', '{value}'), node.value)
 

--- a/unfurl/parsers/parse_url.py
+++ b/unfurl/parsers/parse_url.py
@@ -238,7 +238,9 @@ def run(unfurl, node):
                     parent_id=node.node_id, incoming_edge_config=urlparse_edge)
                 return
 
-        try_url_unquote(unfurl, node)
+        # If the query pair value is itself a URL, parse it as one.
+        if not try_url_parse(unfurl, node):
+            try_url_unquote(unfurl, node)
 
     elif node.data_type == 'url.path.segment':
         for file_type in mimetypes.types_map.keys():

--- a/unfurl/parsers/site_defs/README.md
+++ b/unfurl/parsers/site_defs/README.md
@@ -1,0 +1,304 @@
+# Site Definitions
+
+Site definitions are YAML files that teach Unfurl how to parse URLs for specific websites
+without writing Python code. Each `.yaml` file in this directory defines parsing rules for
+one site's URL structure.
+
+## Requirements
+
+Site definitions require [PyYAML](https://pypi.org/project/PyYAML/) (`pip install pyyaml`).
+Without it, unfurl runs normally but skips all YAML-based site definitions.
+
+## Quick Start
+
+Create a new `.yaml` file in this directory (e.g., `example.yaml`):
+
+```yaml
+name: Example Site
+domains:
+  - example.com
+edge:
+  color: "#FF6600"
+  title: Example Site
+  label: "E"
+
+path_rules:
+  - match:
+      1: users
+    position: 2
+    apply:
+      label: "User: {value}"
+      data_type: example.user_id
+      hover: A user profile identifier.
+```
+
+That's it. Unfurl will automatically load it on the next run. No Python changes needed.
+
+## File Structure
+
+Every site definition has these top-level keys:
+
+```yaml
+name: Human-readable site name
+domains:
+  - example.com          # List of domains this definition applies to.
+  - sub.example.com      # Subdomains of listed domains also match
+                         # (www.example.com matches example.com).
+edge:
+  color: "#hex"          # Color for edges in the unfurl graph
+  title: Edge tooltip    # Tooltip text shown on hover
+  label: "E"             # Short label shown on the edge (emoji works too)
+
+path_rules: [...]        # Rules for URL path segments
+query_rules: [...]       # Rules for query string parameters
+fragment_rules: [...]    # Rules for URL fragments (anchors)
+```
+
+## Path Rules
+
+Path rules match against URL path segments. Unfurl splits the path on `/` and numbers
+segments starting at 1. For `github.com/obsidianforensics/unfurl/issues/42`:
+
+| Position | Value              |
+|----------|--------------------|
+| 1        | obsidianforensics  |
+| 2        | unfurl             |
+| 3        | issues             |
+| 4        | 42                 |
+
+### Position-based rules
+
+Fire when the node's segment position matches. Use `match` to require specific values
+at other positions (sibling segments):
+
+```yaml
+# Match: example.com/users/:user_id
+- match:
+    1: users           # Segment 1 must be "users"
+  position: 2           # This rule fires on segment 2
+  apply:
+    label: "User: {value}"
+    data_type: example.user_id
+    hover: A user identifier.
+```
+
+The `match` map is optional. An empty match (`match: {}`) means the rule fires on any
+URL for this domain at the given position:
+
+```yaml
+# Match: example.com/:username (any first segment)
+- match: {}
+  position: 1
+  apply:
+    label: "Username: {value}"
+    data_type: example.username
+```
+
+### Value-based rules (`on_value`)
+
+Fire when any segment has a specific value, regardless of position:
+
+```yaml
+# Match "wiki" anywhere in the path
+- match: {}
+  on_value: wiki
+  apply:
+    label: "Wiki"
+    data_type: descriptor
+```
+
+You can combine `on_value` with `match` to require context:
+
+```yaml
+# Match "files" only when segment 3 is "pull" (i.e., a PR files view)
+- match:
+    3: pull
+  on_value: files
+  apply:
+    label: "Changed Files"
+    data_type: descriptor
+```
+
+### Excluding values
+
+When using a broad position-based rule (like "segment 1 is a username"), you need to
+exclude known non-matching values. Use `exclude_values`:
+
+```yaml
+- match: {}
+  position: 1
+  exclude_values: [login, settings, search, explore, "*.php"]
+  apply:
+    label: "Profile: {value}"
+    data_type: example.username
+```
+
+`exclude_values` supports wildcards via [fnmatch](https://docs.python.org/3/library/fnmatch.html):
+- `*` matches any characters (e.g., `*.php` matches `profile.php`, `login.php`, etc.)
+- `?` matches a single character
+- `[seq]` matches any character in seq
+
+Plain strings are exact matches. Wildcards and exact strings can be mixed freely.
+
+### Excluding by sibling
+
+Use `exclude_sibling` to skip when a sibling segment has certain values.
+Supports the same wildcards as `exclude_values`:
+
+```yaml
+- match: {}
+  position: 2
+  exclude_sibling:
+    key: 1                           # Check segment at position 1
+    values: [login, join, settings]  # Skip if segment 1 has any of these
+  apply:
+    label: "Repo: {value}"
+    data_type: example.repo
+```
+
+### Rule priority
+
+Rules are evaluated in order. **The first matching rule wins** for each node. Put more
+specific rules before general ones:
+
+```yaml
+# Specific: stories/highlights/ID
+- match:
+    1: stories
+    2: highlights
+  position: 3
+  apply:
+    label: "Highlight: {value}"
+
+# General: stories/USERNAME
+- match:
+    1: stories
+  position: 2
+  apply:
+    label: "Stories by: {value}"
+```
+
+## Query Rules
+
+Query rules match URL query parameters (`?key=value`) by their key name:
+
+```yaml
+query_rules:
+  - key: q
+    apply:
+      label: "Search: {value}"
+      data_type: example.search_query
+      hover: The search query string.
+```
+
+### Hover-only rules
+
+To add hover text to an existing parameter without creating a child node,
+use `hover_only`:
+
+```yaml
+  - key: __tn__
+    apply:
+      hover_only: true
+      hover: >-
+        Content type/rendering flags.
+```
+
+### Parsing values as URLs
+
+Set `data_type: url` to have unfurl parse the parameter value as a full URL:
+
+```yaml
+  - key: redirect_uri
+    apply:
+      label: "Redirect: {value}"
+      data_type: url
+      hover: The OAuth redirect URL.
+```
+
+## Fragment Rules
+
+Fragment rules match the URL fragment (the part after `#`) using regular expressions:
+
+```yaml
+fragment_rules:
+  # Match #L10 or #L10-L20
+  - pattern: "^L(?P<start>\\d+)(?:-L(?P<end>\\d+))?$"
+    apply:
+      label: "Lines {start}-{end}"
+      label_single: "Line {start}"   # Used when {end} group is absent
+      data_type: example.line_ref
+      hover: A line number reference.
+```
+
+Named regex groups (e.g., `(?P<start>\\d+)`) become placeholders in labels. If a group
+named `end` is absent (didn't match), the `label_single` template is used instead of `label`.
+
+**Note:** YAML requires escaping backslashes in regex patterns. Use `\\d` not `\d`.
+
+## Label Templates
+
+All `label` fields support `{value}` as a placeholder for the node's value:
+
+```yaml
+label: "User: {value}"      # -> "User: obsidianforensics"
+label: "Issue #{value}"      # -> "Issue #42"
+```
+
+Fragment rules also support named group placeholders:
+
+```yaml
+label: "Lines {start}-{end}" # -> "Lines 10-20"
+```
+
+## The `apply` Block
+
+Every rule has an `apply` block that defines what unfurl does when the rule matches:
+
+| Field       | Required | Description |
+|-------------|----------|-------------|
+| `label`     | No       | Display label (supports `{value}` placeholder). Defaults to `{value}`. |
+| `data_type` | No       | The data type for the created node. Defaults to `descriptor`. |
+| `hover`     | No       | Hover/tooltip text (supports HTML like `<br>`, `<b>`, `<a>`). |
+| `hover_only`| No       | If `true`, just sets hover text on the existing node (query rules only). |
+
+### Choosing a `data_type`
+
+- Use `descriptor` (the default) for informational labels that don't need further parsing.
+- Use a site-specific type like `github.commit_hash` or `facebook.post_id` for values
+  that might be parsed further by other unfurl parsers.
+- Use `url` to have unfurl parse the value as a complete URL (useful for redirect parameters).
+- Use timestamp types like `epoch-seconds` or `epoch-microseconds` to trigger unfurl's
+  timestamp parser.
+
+## Testing
+
+Write unit tests in `unfurl/tests/unit/`. Use `has_node()` to check for specific nodes
+by data_type, key, or value rather than checking exact node counts (which are fragile):
+
+```python
+from unfurl.core import Unfurl
+import unittest
+
+def has_node(unfurl_instance, **kwargs):
+    for node in unfurl_instance.nodes.values():
+        if all(getattr(node, k) == v for k, v in kwargs.items()):
+            return True
+    return False
+
+class TestExample(unittest.TestCase):
+    def test_user_url(self):
+        test = Unfurl()
+        test.add_to_queue(data_type='url', key=None,
+                          value='https://example.com/johndoe')
+        test.parse_queue()
+
+        self.assertTrue(has_node(test, data_type='example.username', value='johndoe'))
+```
+
+## Examples
+
+See the existing definitions in this directory for complete examples:
+- `github.yaml` - Path rules, query rules, fragment rules, exclude_sibling
+- `facebook.yaml` - Complex path rules, wildcard excludes, hover_only query rules
+- `instagram.yaml` - Multiple URL formats for the same content type

--- a/unfurl/parsers/site_defs/facebook.yaml
+++ b/unfurl/parsers/site_defs/facebook.yaml
@@ -1,0 +1,291 @@
+# Facebook URL parser definition
+# Parsed by parse_site_defs.py
+
+name: Facebook
+domains:
+  - facebook.com
+edge:
+  color: "#1877F2"
+  title: Facebook
+  label: "f"
+
+path_rules:
+
+  # --- Posts ---
+  # facebook.com/USERNAME/posts/POST_ID
+  - match:
+      2: posts
+    position: 3
+    apply:
+      label: "Post: {value}"
+      data_type: facebook.post_id
+      hover: >-
+        A Facebook post ID. Older posts use numeric IDs; newer posts
+        (since ~2022) use "pfbid" format, which Meta describes as a
+        "time-rotating pseudonymized identifier" combining the original
+        FBID and a timestamp. No known method exists to decode pfbids
+        offline; the numeric ID can be extracted by fetching the post
+        page and reading the share_fbid from the HTML.
+        <a href="https://about.fb.com/news/2022/09/deterring-scraping-by-protecting-facebook-identifiers/"
+        target="_blank">[ref]</a>
+
+  # --- Photos ---
+  # facebook.com/USERNAME/photos/PHOTO_ID
+  - match:
+      2: photos
+    position: 3
+    apply:
+      label: "Photo: {value}"
+      data_type: facebook.photo_id
+      hover: >-
+        A Facebook photo ID or photo set identifier.
+
+  # --- Videos ---
+  # facebook.com/USERNAME/videos/VIDEO_ID
+  - match:
+      2: videos
+    position: 3
+    apply:
+      label: "Video: {value}"
+      data_type: facebook.video_id
+      hover: >-
+        A Facebook video ID.
+
+  # facebook.com/watch?v=VIDEO_ID
+  - match: {}
+    on_value: watch
+    apply:
+      label: "Watch"
+      data_type: descriptor
+
+  # --- Groups ---
+  # facebook.com/groups/GROUP_ID_OR_NAME/
+  - match:
+      1: groups
+    position: 2
+    apply:
+      label: "Group: {value}"
+      data_type: facebook.group_id
+      hover: >-
+        A Facebook group ID or vanity name.
+
+  # --- Events ---
+  # facebook.com/events/EVENT_ID/
+  - match:
+      1: events
+    position: 2
+    apply:
+      label: "Event: {value}"
+      data_type: facebook.event_id
+      hover: >-
+        A Facebook event ID.
+
+  # --- Stories ---
+  # facebook.com/stories/STORY_ID
+  - match:
+      1: stories
+    position: 2
+    apply:
+      label: "Story: {value}"
+      data_type: facebook.story_id
+      hover: >-
+        A Facebook story ID.
+
+  # --- Pages ---
+  # facebook.com/pages/PAGE_NAME/PAGE_ID
+  - match:
+      1: pages
+    position: 2
+    apply:
+      label: "Page: {value}"
+      data_type: facebook.page_name
+      hover: >-
+        A Facebook Page name (from the legacy Pages URL format).
+
+  - match:
+      1: pages
+    position: 3
+    apply:
+      label: "Page ID: {value}"
+      data_type: facebook.page_id
+      hover: >-
+        A Facebook Page numeric ID.
+
+  # --- Share ---
+  # facebook.com/share/p/SHARE_ID/ or /share/r/SHARE_ID/
+  - match:
+      1: share
+    position: 3
+    apply:
+      label: "Share: {value}"
+      data_type: facebook.share_id
+      hover: >-
+        A Facebook share link ID.
+
+  # facebook.com/share/SHARE_ID/ (without type prefix)
+  - match:
+      1: share
+    position: 2
+    exclude_values: [p, r, v]
+    apply:
+      label: "Share: {value}"
+      data_type: facebook.share_id
+      hover: >-
+        A Facebook share link ID.
+
+  # --- Marketplace ---
+  # facebook.com/marketplace/item/ITEM_ID/
+  - match:
+      1: marketplace
+      2: item
+    position: 3
+    apply:
+      label: "Marketplace Item: {value}"
+      data_type: facebook.marketplace_id
+      hover: >-
+        A Facebook Marketplace listing ID.
+
+  # --- Profile username (first path segment) ---
+  - match: {}
+    position: 1
+    exclude_values: [groups, events, pages, stories, share, marketplace,
+                     watch, search, login, recover, help, settings, bookmarks,
+                     notifications, messages, friends, gaming, fundraisers,
+                     "*.php", plugins, hashtag, explore, reel, reels, ads,
+                     business, privacy, policies, about, careers, developers,
+                     security, lite]
+    apply:
+      label: "Profile: {value}"
+      data_type: facebook.username
+      hover: >-
+        A Facebook profile or Page vanity URL username.
+
+# Query parameter rules
+query_rules:
+
+  # l.facebook.com/l.php?u=ENCODED_URL
+  - key: u
+    apply:
+      hover_only: true
+      hover: >-
+        The destination URL in a Facebook outbound redirect link
+        (l.facebook.com/l.php). This is the URL the user was sent
+        to after clicking an external link on Facebook.
+
+  # l.facebook.com/l.php?h=HASH
+  - key: h
+    apply:
+      hover_only: true
+      hover: >-
+        Facebook link verification hash. Used to validate the redirect
+        URL hasn't been tampered with.
+
+  - key: hash
+    apply:
+      hover_only: true
+      hover: >-
+        Facebook link verification hash (lsr.php variant).
+
+  - key: enc
+    apply:
+      hover_only: true
+      hover: >-
+        Suspected Facebook tracking parameter.
+
+  - key: s
+    apply:
+      hover_only: true
+      hover: >-
+        Facebook link shim parameter. Part of the redirect link
+        verification system.
+
+  - key: __tn__
+    apply:
+      hover_only: true
+      hover: >-
+        Suspected Facebook content type/rendering flags.
+
+  - key: __cft__[0]
+    apply:
+      hover_only: true
+      hover: >-
+        Suspected Facebook tracking parameter.
+
+  - key: hc_ref
+    apply:
+      hover_only: true
+      hover: >-
+        Facebook referral context. Indicates where on Facebook the user
+        came from (e.g. PAGES_TIMELINE, news feed, notification).
+
+  # lsr.php?ext=TIMESTAMP
+  - key: ext
+    apply:
+      hover_only: true
+      hover: >-
+        A Unix timestamp in a Facebook redirect link (lsr.php),
+        thought to indicate when the link was generated or clicked.
+
+  # profile.php?id=USER_ID
+  - key: id
+    apply:
+      label: "User/Page ID: {value}"
+      data_type: facebook.user_id
+      hover: >-
+        A Facebook numeric user or Page ID.
+
+  # story.php params
+  - key: story_fbid
+    apply:
+      label: "Story FBID: {value}"
+      data_type: facebook.story_fbid
+      hover: >-
+        A Facebook story or post FBID (Facebook ID). This identifies
+        the specific story or post being viewed.
+
+  # mibextid - mobile browser extension ID
+  - key: mibextid
+    apply:
+      hover_only: true
+      hover: >-
+        Facebook Mobile In-Browser Extension ID. Indicates the link was
+        opened or shared from a Facebook mobile app. Common values:
+        ZbWKwL (Android), LQQJ4d (iOS), wwXIfr (share sheet).
+
+  # Share/referral params
+  - key: comment_id
+    apply:
+      label: "Comment: {value}"
+      data_type: facebook.comment_id
+      hover: >-
+        A Facebook comment ID, linking to a specific comment on a post.
+
+  - key: reply_comment_id
+    apply:
+      label: "Reply: {value}"
+      data_type: facebook.reply_comment_id
+      hover: >-
+        A Facebook reply comment ID.
+
+  - key: notif_id
+    apply:
+      hover_only: true
+      hover: >-
+        A Facebook notification ID that led the user to this URL.
+
+  - key: notif_t
+    apply:
+      label: "Notification Type: {value}"
+      data_type: facebook.notification_type
+      hover: >-
+        The type of Facebook notification (e.g. mentions_reply,
+        group_activity, comment_mention).
+
+  # Sharer
+  - key: app_id
+    apply:
+      label: "App ID: {value}"
+      data_type: facebook.app_id
+      hover: >-
+        A Facebook application ID identifying which app generated
+        or shared this link.

--- a/unfurl/parsers/site_defs/instagram.yaml
+++ b/unfurl/parsers/site_defs/instagram.yaml
@@ -153,8 +153,7 @@ query_rules:
   # l.instagram.com/?u=ENCODED_URL&e=TRACKING
   - key: u
     apply:
-      label: "Redirect to: {value}"
-      data_type: url
+      hover_only: true
       hover: >-
         The destination URL in an Instagram outbound redirect
         (l.instagram.com). The URL the user was sent to after
@@ -162,10 +161,10 @@ query_rules:
 
   - key: e
     apply:
-      label: "Tracking: {value}"
-      data_type: instagram.redirect_tracking
+      hover_only: true
       hover: >-
-        A tracking token in an Instagram outbound redirect link.
+        Instagram redirect tracking token. Value is included
+        on l.instagram.com outbound redirect links.
 
   - key: igshid
     apply:

--- a/unfurl/parsers/site_defs/instagram.yaml
+++ b/unfurl/parsers/site_defs/instagram.yaml
@@ -169,17 +169,14 @@ query_rules:
 
   - key: igshid
     apply:
-      label: "Share ID: {value}"
-      data_type: instagram.share_id
+      hover_only: true
       hover: >-
-        Instagram share ID. A base64-encoded value added when a link
-        is shared through the Instagram app. Can indicate the sharing
-        method/platform.
+        Instagram share ID; thought to be a base64-encoded value added when
+        a link is shared through the Instagram app.
 
   - key: igsh
     apply:
-      label: "Share ID: {value}"
-      data_type: instagram.share_id
+      hover_only: true
       hover: >-
         Instagram share ID (short form). Same as igshid but with a
         shorter parameter name used in newer app versions.

--- a/unfurl/tests/unit/test_facebook.py
+++ b/unfurl/tests/unit/test_facebook.py
@@ -1,0 +1,129 @@
+from unfurl.core import Unfurl
+import unittest
+
+
+def has_node(unfurl_instance, **criteria):
+    """Check if a node matching all given criteria exists."""
+    for node in unfurl_instance.nodes.values():
+        if all(getattr(node, attr, None) == val for attr, val in criteria.items()):
+            return True
+    return False
+
+
+class TestFacebook(unittest.TestCase):
+
+    def _unfurl(self, url):
+        u = Unfurl(remote_lookups=False)
+        u.add_to_queue(data_type='url', key=None, value=url)
+        u.parse_queue()
+        return u
+
+    def test_redirect_l_php(self):
+        """l.facebook.com/l.php params get hover only; URL is still parsed by parse_url."""
+        u = self._unfurl(
+            'https://l.facebook.com/l.php?u=https%3A%2F%2Fdata.austintexas.gov'
+            '%2FGovernment%2FAustin-311-Public-Data%2Fxwdj-i9he&h=NAQFbBxGv')
+        # u and h get hover text only from our parser
+        for node in u.nodes.values():
+            if node.data_type == 'url.query.pair' and node.key == 'h':
+                self.assertIn('verification hash', node.hover)
+                break
+        for node in u.nodes.values():
+            if node.data_type == 'url.query.pair' and node.key == 'u':
+                self.assertIn('destination URL', node.hover)
+                break
+
+    def test_redirect_lsr_php_hover(self):
+        """lsr.php ext param gets hover only"""
+        u = self._unfurl(
+            'http://l.facebook.com/lsr.php?u=https%3A%2F%2Fdata.cityofnewyork.us'
+            '%2FCity-Government%2F1-foot-Digital-Elevation-Model-DEM-%2Fdpc8-z3jc'
+            '&ext=1442879836&hash=AcnnZ5k0wBh4ZaGZFmBXimGK')
+        for node in u.nodes.values():
+            if node.data_type == 'url.query.pair' and node.key == 'ext':
+                self.assertIn('timestamp', node.hover.lower())
+                break
+
+    def test_profile_php_id(self):
+        """profile.php?id= extracts user ID"""
+        u = self._unfurl('https://www.facebook.com/profile.php?id=100066300129450')
+        self.assertTrue(has_node(u, data_type='facebook.user_id', value='100066300129450'))
+
+    def test_profile_username_with_post(self):
+        """Vanity URL extracts username and post ID"""
+        u = self._unfurl('https://ja-jp.facebook.com/BWIairport/posts/1176825889031565')
+        self.assertTrue(has_node(u, data_type='facebook.username', value='BWIairport'))
+        self.assertTrue(has_node(u, data_type='facebook.post_id', value='1176825889031565'))
+
+    def test_group_url(self):
+        """Group URL extracts group ID"""
+        u = self._unfurl('https://www.facebook.com/groups/563959120410492/')
+        self.assertTrue(has_node(u, data_type='facebook.group_id', value='563959120410492'))
+
+    def test_story_php(self):
+        """story.php extracts story_fbid and user id"""
+        u = self._unfurl(
+            'https://m.facebook.com/story.php?story_fbid=858120630879651&id=100000451660358')
+        self.assertTrue(has_node(u, data_type='facebook.story_fbid', value='858120630879651'))
+        self.assertTrue(has_node(u, data_type='facebook.user_id', value='100000451660358'))
+
+    def test_share_with_type(self):
+        """Share URL with type prefix (/share/p/ID/)"""
+        u = self._unfurl('https://www.facebook.com/share/p/1E8garP5Dy/')
+        self.assertTrue(has_node(u, data_type='facebook.share_id', value='1E8garP5Dy'))
+        self.assertFalse(has_node(u, data_type='facebook.share_id', value='p'))
+
+    def test_comment_and_notification(self):
+        """Post URL with comment_id and notif_t params"""
+        u = self._unfurl(
+            'https://www.facebook.com/user/posts/123?comment_id=456&notif_t=mentions_reply')
+        self.assertTrue(has_node(u, data_type='facebook.comment_id', value='456'))
+        self.assertTrue(has_node(u, data_type='facebook.notification_type', value='mentions_reply'))
+
+    def test_event_url(self):
+        """Event URL extracts event ID"""
+        u = self._unfurl('https://www.facebook.com/events/1234567890/')
+        self.assertTrue(has_node(u, data_type='facebook.event_id', value='1234567890'))
+
+    def test_fbclid_modern(self):
+        """Modern fbclid (IwZX format) extracts browser ID and app ID"""
+        u = self._unfurl(
+            'https://www.eventbrite.com/e/pitttsburgh-balloon-glow-tickets-882726989187'
+            '?fbclid=IwZXh0bgNhZW0CMTAAAR08WkoWnFZTweGu-0q0ewW1Sb7Y8mCHmEWJj1c_tD8LNQ0fBMStjzt_TPo'
+            '_aem_Ab2eTPHa-b2DTYiz')
+        self.assertTrue(has_node(u, data_type='facebook.fbclid.extn', value='aem'))
+        self.assertTrue(has_node(u, data_type='facebook.fbclid.aem_hash'))
+
+    def test_fbclid_old_format(self):
+        """Old fbclid (IwAR format) should not produce decoded fields"""
+        u = self._unfurl(
+            'https://nyc.streetsblog.org/2020/01/08/nypd-targets-blacks-and-latinos-for-jaywalking-tickets'
+            '/?fbclid=IwAR054Z27sI8LALyasatpqO8a0LdH4-PiLp41TZiUrgxq1fUCg7Pyynm7kRA')
+        self.assertFalse(has_node(u, data_type='facebook.fbclid.extn'))
+        self.assertFalse(has_node(u, data_type='facebook.fbclid.brid'))
+
+    def test_mibextid_hover(self):
+        """mibextid param gets hover text but no child node"""
+        u = self._unfurl(
+            'https://www.facebook.com/profile.php?id=100015308826341&mibextid=ZbWKwL')
+        self.assertFalse(has_node(u, data_type='facebook.mibextid'))
+        for node in u.nodes.values():
+            if node.data_type == 'url.query.pair' and node.key == 'mibextid':
+                self.assertIn('Mobile', node.hover)
+                break
+        else:
+            self.fail('mibextid query pair node not found')
+
+    def test_no_profile_on_static_pages(self):
+        """Static pages should not be labeled as profiles"""
+        u = self._unfurl('https://www.facebook.com/groups/mygroup/')
+        self.assertFalse(has_node(u, data_type='facebook.username', value='groups'))
+
+    def test_stories_url(self):
+        """Stories URL extracts story ID"""
+        u = self._unfurl('https://www.facebook.com/stories/287202590802695')
+        self.assertTrue(has_node(u, data_type='facebook.story_id', value='287202590802695'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unfurl/tests/unit/test_instagram.py
+++ b/unfurl/tests/unit/test_instagram.py
@@ -50,20 +50,25 @@ class TestInstagram(unittest.TestCase):
         self.assertFalse(has_node(u, data_type='epoch-milliseconds'))
 
     def test_redirect_url(self):
-        """l.instagram.com redirect parses destination URL"""
+        """l.instagram.com redirect parses destination URL; e gets hover only"""
         u = self._unfurl('https://l.instagram.com/?u=https%3A%2F%2Fexample.com%2Fpage&e=ATMnj6KS')
         self.assertTrue(has_node(u, value='example.com'))
-        self.assertTrue(has_node(u, data_type='instagram.redirect_tracking', value='ATMnj6KS'))
+        # e should get hover only, not a child node
+        self.assertFalse(has_node(u, data_type='instagram.redirect_tracking'))
 
-    def test_share_id_igshid(self):
-        """igshid query parameter"""
+    def test_share_id_igshid_hover(self):
+        """igshid gets hover text, not a child node"""
         u = self._unfurl('https://instagram.com/user123?igshid=NTc4MTIwNjQ2YQ==')
-        self.assertTrue(has_node(u, data_type='instagram.share_id', value='NTc4MTIwNjQ2YQ=='))
+        self.assertFalse(has_node(u, data_type='instagram.share_id'))
+        for node in u.nodes.values():
+            if node.data_type == 'url.query.pair' and node.key == 'igshid':
+                self.assertIn('share id', node.hover.lower())
+                break
 
-    def test_share_id_igsh(self):
-        """igsh query parameter (newer format)"""
+    def test_share_id_igsh_hover(self):
+        """igsh gets hover text, not a child node"""
         u = self._unfurl('https://www.instagram.com/reel/DWbNC2OEilE/?igsh=MWdkOWZ3NHZ0ZngzMQ==')
-        self.assertTrue(has_node(u, data_type='instagram.share_id', value='MWdkOWZ3NHZ0ZngzMQ=='))
+        self.assertFalse(has_node(u, data_type='instagram.share_id'))
 
     def test_language_param(self):
         """hl language parameter"""


### PR DESCRIPTION
…, a Python parser for fbclid, and comprehensive unit tests. Update Instagram parser to mark igshid and igsh parameters as hover-only.


- [x] Tests pass
- [x] Appropriate changes to README are included in PR