### PR TITLE
Expand Google URL parameter handling

### DIFF
--- a/unfurl/parsers/parse_site_defs.py
+++ b/unfurl/parsers/parse_site_defs.py
@@ -170,13 +170,12 @@ def _check_query_rule(unfurl, node, rule, site_def):
     edge_config = site_def['_edge_config']
     label = _format_label(apply.get('label', '{value}'), node.value)
 
-    # If data_type is 'url', we want the value to be parsed as a URL
     data_type = apply.get('data_type', 'descriptor')
 
     unfurl.add_to_queue(
         data_type=data_type,
         key=None,
-        value=node.value,
+        value=node.value if data_type != 'descriptor' else None,
         label=label,
         hover=apply.get('hover', ''),
         parent_id=node.node_id,

--- a/unfurl/parsers/site_defs/google.yaml
+++ b/unfurl/parsers/site_defs/google.yaml
@@ -7,8 +7,8 @@ name: Google
 domains:
   - google.com
 edge:
-  color: "#4285F4"
-  title: Google
+  color: green
+  title: Google-related Parsing Functions
   label: "G"
 
 # --- /url redirect pages ---
@@ -39,10 +39,9 @@ query_rules:
     apply:
       hover_only: true
       hover: >-
-        Google redirect action type. Common values:
-        <b>t</b> = standard redirect (from search results),
-        <b>D</b> = redirect from a Google product (Docs, Hangouts, etc.),
-        <b>U</b> = redirect from a Google Cache page.
+        Suspected Google redirect action type. Most commonly observed 
+        value is <b>t</b>; other observed values include
+        <b>f</b>, <b>i</b>, <b>D</b>, <b>U</b>, <b>z</b>, <b>j</b>, & <b>X</b>. 
 
   - key: usg
     path: /url
@@ -74,14 +73,35 @@ query_rules:
     apply:
       hover_only: true
       hover: >-
-        Redirect confirmation type. Typically <b>j</b> (JavaScript redirect).
+        Suspected "redirect confirmation type"; typically <b>j</b>.
 
-  - key: esrc
+  - key: source
     path: /url
     apply:
       hover_only: true
       hover: >-
-        Source of the redirect. Typically <b>s</b> (search).
+        Google product/surface the redirect originated from. Most common
+        value is <b>web</b> (~99%). Other observed values: <b>finance</b>,
+        <b>imgres</b> / <b>images</b> (Image Search), <b>blogsearch</b>,
+        <b>transpromo</b>, and <code>gbs_*</code> (Google Books).
+
+  - key: cd
+    path: /url
+    apply:
+      hover_only: true
+      hover: >-
+        Suspected <b>"click depth"</b> — the position (1-based) of the
+        clicked result on the referring page. Most values are small
+        integers 1–10; longer values are observed but rare. 
+
+  - key: sig2
+    path: /url
+    apply:
+      hover_only: true
+      hover: >-
+        Secondary signature. 22-character URL-safe base64; values are
+        nearly always unique. Purpose not publicly documented; presumed
+        cryptographic verification of the redirect, like <code>usg</code>.
 
   # --- /imgres (image result pages) ---
 
@@ -153,5 +173,106 @@ query_rules:
     apply:
       hover_only: true
       hover: >-
-        Interaction action type — how the user reached this image result.
+        Suspected "interaction click type" — how the user reached this image result.
         Common values: <b>rc</b> = right-click, <b>hc</b> = hover-click.
+
+  # --- /aclk (ad click tracking) ---
+  # google.com/aclk?sa=L&ai=...&sig=AOD64_...&adurl=DESTINATION&...
+  # This endpoint records ad clicks and redirects to the advertiser's landing page.
+
+  - key: adurl
+    path: /aclk
+    apply:
+      label: "Ad Destination"
+      data_type: descriptor
+      hover: >-
+        The advertiser's <b>landing page URL</b> (the destination the
+        user is sent to after clicking the Google ad).
+
+  - key: ai
+    path: /aclk
+    apply:
+      hover_only: true
+      hover: >-
+        Opaque blob (URL-safe base64) attached to ad-click
+        redirects. The decoded bytes use a non-standard framing (a 1-byte
+        prefix before any protobuf content); contents are not
+        publicly documented by Google.
+
+  - key: sig
+    path: /aclk
+    apply:
+      hover_only: true
+      hover: >-
+        Google ad click <b>signature</b>. Verifies the click was generated
+        by Google's ad serving infrastructure and has not been tampered with.
+
+  - key: sa
+    path: /aclk
+    apply:
+      hover_only: true
+      hover: >-
+        Suspected Google ad action type. Nearly always <b>l</b> or <b>L</b>.
+
+  - key: gclid
+    path: /aclk
+    apply:
+      hover_only: true
+      hover: >-
+        <b>Google Click ID</b> — a unique identifier for this ad click, passed
+        to the advertiser's landing page for conversion tracking.
+
+  - key: ctype
+    path: /aclk
+    apply:
+      hover_only: true
+      hover: >-
+        Suspected "content interaction type" is an integer; meaning is not
+        publicly documented by Google. 
+
+  - key: ved
+    path: /aclk
+    apply:
+      hover_only: true
+      hover: >-
+        Google tracking parameter encoding the ad's position and type on
+        the search results page. Contains a protobuf-encoded structure.
+
+  - key: cid
+    path: /aclk
+    apply:
+      hover_only: true
+      hover: >-
+        Suspected <b>"click identifier"</b>. The value often is a URL-safe 
+        base64-encoded 2-field protobuf envelope: a small varint flag
+        and an opaque high-entropy payload blob.
+
+  - key: rct
+    path: /aclk
+    apply:
+      hover_only: true
+      hover: >-
+        Suspected "redirect confirmation type"; typically <b>j</b>.
+
+  - key: nis
+    path: /aclk
+    apply:
+      hover_only: true
+      hover: >-
+        Suspected <b>"number of impression slots"</b>; possibly the count
+        of ad slots visible on the page.
+
+  - key: ase
+    path: /aclk
+    apply:
+      hover_only: true
+      hover: >-
+        Purpose unknown; typically <b>2</b>.
+
+  - key: category
+    path: /aclk
+    apply:
+      hover_only: true
+      hover: >-
+        Suspected ad category code. All observed values match
+        <b>acrcp_v1_N</b>. 

--- a/unfurl/tests/unit/test_google.py
+++ b/unfurl/tests/unit/test_google.py
@@ -140,5 +140,55 @@ class TestGoogle(unittest.TestCase):
         self.assertIn('signature', usg_node.hover.lower())
 
 
+    def test_google_aclk_ad_click(self):
+        """Test that google.com/aclk ad click URLs are parsed correctly.
+
+        The adurl parameter is the advertiser's landing page and should be
+        parsed as a URL. Tracking params (ai, sig, gclid, etc.) get hover text.
+        """
+
+        test = Unfurl()
+        test.remote_lookups = False
+        test.add_to_queue(
+            data_type='url', key=None,
+            value='https://www.google.com/aclk?sa=L&ai=DChcSEwiE4ujK09SFAxWYroMHHfGZAigYABAAGgJlZg'
+                  '&sig=AOD64_01K4cZUGNjr9xJflXR3zH81_Do6w'
+                  '&gclid=EAIaIQobChMIhOLoytPUhQMVmK6DBx3xmQIoEAMYASAAEgIYYfD_BwE'
+                  '&adurl=https://example.com/landing-page%3Futm_source%3Dgoogle'
+                  '&ved=2ahUKEwiE4ujK09SFAxWYroMHHfGZAigQgQ16BAgDEAE')
+        test.parse_queue()
+
+        # adurl should be parsed as a destination URL node
+        adurl_nodes = [
+            n for n in test.nodes.values()
+            if n.data_type == 'url'
+            and urlparse(str(n.value)).hostname == 'example.com'
+        ]
+        self.assertGreaterEqual(len(adurl_nodes), 1)
+
+        # adurl child node should have "Ad Destination" label
+        adurl_labeled = [n for n in test.nodes.values()
+                         if 'Ad Destination' in (n.label or '')]
+        self.assertGreaterEqual(len(adurl_labeled), 1)
+
+        # ai should have hover text about ad metadata
+        ai_node = next(n for n in test.nodes.values()
+                       if n.data_type == 'url.query.pair' and n.key == 'ai')
+        self.assertIsNotNone(ai_node.hover)
+        self.assertIn('ad', ai_node.hover.lower())
+
+        # sig should have hover text about signature
+        sig_node = next(n for n in test.nodes.values()
+                        if n.data_type == 'url.query.pair' and n.key == 'sig')
+        self.assertIsNotNone(sig_node.hover)
+        self.assertIn('signature', sig_node.hover.lower())
+
+        # gclid should have hover text
+        gclid_node = next(n for n in test.nodes.values()
+                          if n.data_type == 'url.query.pair' and n.key == 'gclid')
+        self.assertIsNotNone(gclid_node.hover)
+        self.assertIn('click', gclid_node.hover.lower())
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Move and enhance parsing for additional Google URL parameters into `site_defs/google.yaml`. Add `/aclk` endpoint handling, including ad-related parameters (e.g., `adurl`, `ai`, `sig`, `gclid`). Update hover text with new details. Add unit test for `/aclk` parsing. Refactor `_edge_config` logic to account for `descriptor` data type.

- [ ] Tests pass
