### PR TITLE
Add parsing of Python's `itsdangerous` URLSafeTimedSerializer (simila…

### DIFF
--- a/unfurl/cli.py
+++ b/unfurl/cli.py
@@ -92,3 +92,7 @@ def command_line_interface():
                     detailed=args.detailed, output_filter=args.filter))
             print()
             unfurl_instance.reset_graph_state()
+
+
+if __name__ == '__main__':
+    command_line_interface()

--- a/unfurl/core.py
+++ b/unfurl/core.py
@@ -302,19 +302,6 @@ class Unfurl:
         return new_node.node_id
 
     @staticmethod
-    def add_b64_padding(encoded_string):
-        encoded_string = encoded_string.rstrip('=')
-        remainder = len(encoded_string) % 4
-        if remainder == 1:
-            return False
-        elif remainder == 2:
-            return f'{encoded_string}=='
-        elif remainder == 3:
-            return f'{encoded_string}='
-        else:
-            return encoded_string
-
-    @staticmethod
     def check_if_int_between(value, low, high):
         try:
             value = int(value)

--- a/unfurl/parsers/__init__.py
+++ b/unfurl/parsers/__init__.py
@@ -17,6 +17,7 @@ __all__ = [
     "parse_initial_node",
     "parse_instagram",
     "parse_ip",
+    "parse_itsdangerous",
     "parse_json",
     "parse_jwt",
     "parse_kg",

--- a/unfurl/parsers/parse_base64.py
+++ b/unfurl/parsers/parse_base64.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import base64
-import binascii
 from unfurl import utils
 
 b64_edge = {
@@ -33,16 +31,11 @@ def run(unfurl, node):
     # If a node is explicitly labeled as base64, decode it directly and skip the
     # auto-detection heuristics (length/regex filters and the printable-only gate).
     if node.data_type == 'base64':
-        stripped = node.value.rstrip('=')
-        if len(stripped) % 4 == 1:
-            return
-        padded = stripped + ('=' * (-len(stripped) % 4))
-        try:
-            if '-' in node.value or '_' in node.value:
-                decoded = base64.urlsafe_b64decode(padded)
-            else:
-                decoded = base64.b64decode(padded, validate=True)
-        except (binascii.Error, ValueError):
+        if '-' in node.value or '_' in node.value:
+            decoded = utils.try_urlsafe_b64_decode(node.value)
+        else:
+            decoded = utils.try_standard_b64_decode(node.value)
+        if decoded is None:
             return
         if utils.is_printable_ascii(decoded):
             unfurl.add_to_queue(data_type='string', key=None, value=decoded.decode('ascii'),
@@ -52,32 +45,19 @@ def run(unfurl, node):
                                 parent_id=node.node_id, incoming_edge_config=b64_edge)
         return
 
-    if len(node.value) % 4 == 1:
-        # A valid b64 string will not be this length
-        return False
-
     if node.data_type == 'url.query.pair' and node.key == 'dns':
         return False
 
-    urlsafe_b64_m = utils.urlsafe_b64_re.fullmatch(node.value)
-    standard_b64_m = utils.standard_b64_re.fullmatch(node.value)
-    long_int_m = utils.long_int_re.fullmatch(node.value)
-    all_letters_m = utils.letters_re.fullmatch(node.value)
-
     # Long integers and normal words pass the b64 regex, but we don't want those here.
     # It's technically valid base64, but to reduce false positives, we're filtering them out.
-    if long_int_m or all_letters_m:
+    if utils.long_int_re.fullmatch(node.value) or utils.letters_re.fullmatch(node.value):
         return
 
-    decoded = None
-    padded_value = unfurl.add_b64_padding(node.value)
-    if not padded_value:
-        return
-
-    if urlsafe_b64_m:
-        decoded = base64.urlsafe_b64decode(padded_value)
-    elif standard_b64_m:
-        decoded = base64.b64decode(padded_value)
+    # Require a minimum encoded length of 8 as another false-positive gate; short
+    # values are too likely to be something else that happens to decode.
+    decoded = utils.try_urlsafe_b64_decode(node.value, min_length=8)
+    if decoded is None:
+        decoded = utils.try_standard_b64_decode(node.value, min_length=8)
 
     # Require printable output. This limits the plugin to ASCII strings that were
     # base64-encoded; a wrong guess almost always decodes to control-character

--- a/unfurl/parsers/parse_compressed.py
+++ b/unfurl/parsers/parse_compressed.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import base64
 import re
 import zlib
 from unfurl import utils
@@ -88,19 +87,14 @@ def run(unfurl, node):
     # not useful clutter, so the decode happens here and we only emit on success.
     attempts = []
 
-    # base64 candidate. A valid b64 string is never length % 4 == 1, and long
-    # integers pass the b64 regex but aren't what we want here.
-    if len(node.value) % 4 != 1 and not utils.long_int_re.fullmatch(node.value):
-        padded_value = unfurl.add_b64_padding(node.value)
-        if padded_value:
-            decoded = None
-            if utils.urlsafe_b64_re.fullmatch(node.value):
-                decoded = base64.urlsafe_b64decode(padded_value)
-            elif utils.standard_b64_re.fullmatch(node.value):
-                decoded = base64.b64decode(padded_value)
-            if decoded:
-                attempts.append((decoded, b64_zip_edge,
-                                 'This data was base64-decoded, then zlib inflated'))
+    # base64 candidate. Long integers pass the b64 regex but aren't what we want here.
+    if not utils.long_int_re.fullmatch(node.value):
+        decoded = utils.try_urlsafe_b64_decode(node.value, min_length=8)
+        if decoded is None:
+            decoded = utils.try_standard_b64_decode(node.value, min_length=8)
+        if decoded:
+            attempts.append((decoded, b64_zip_edge,
+                             'This data was base64-decoded, then zlib inflated'))
 
     # base32 candidate.
     b32_decoded = utils.try_base32_decode(node.value)

--- a/unfurl/parsers/parse_discord.py
+++ b/unfurl/parsers/parse_discord.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2026 Ryan Benson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unfurl import utils
+
 import logging
 log = logging.getLogger(__name__)
 
@@ -22,6 +24,18 @@ discord_edge = {
     'title': 'Discord Snowflake',
     'label': '❄'
 }
+
+def create_discord_id(timestamp=None, days_ahead=None, worker_id=0, process_id=0, increment=0):
+    id_timestamp = utils.create_epoch_seconds_timestamp(
+        iso_timestamp=timestamp, days_ahead=days_ahead, offset=1420070400)
+
+    # Multiply the timestamp by 1000, as Discord uses a millisecond timestamp
+    timestamp_bits = utils.set_bits(id_timestamp * 1000, 22)
+    worker_id_bits = utils.set_bits(worker_id, 17)
+    process_id_bits = utils.set_bits(process_id, 12)
+    increment_bits = utils.set_bits(increment, 0)
+
+    return int(timestamp_bits + worker_id_bits + process_id_bits + increment_bits)
 
 
 def parse_discord_snowflake(unfurl, node):
@@ -35,7 +49,7 @@ def parse_discord_snowflake(unfurl, node):
         # Ref: https://discordapp.com/developers/docs/reference#snowflakes
         timestamp = (snowflake >> 22) + 1420070400000
         worker_id = (snowflake & 0x3E0000) >> 17
-        internal_process_id = (snowflake & 0x1F000) >> 17
+        internal_process_id = (snowflake & 0x1F000) >> 12
         increment = snowflake & 0xFFF
 
     except Exception as e:
@@ -71,6 +85,11 @@ def run(unfurl, node):
     # Known patterns from main Discord site
     discord_domains = ['discordapp.com', 'discordapp.net', 'discord.com']
     if any(unfurl.preceding_domain_matches(node, d) for d in discord_domains):
+        # Make sure a potential Snowflake is reasonable: between 2015-02-01
+        # (shortly before Discord launched) & a year from now
+        min_reasonable_id = create_discord_id('2015-02-01T00:00:00')
+        max_reasonable_id = create_discord_id(days_ahead=365)
+
         if node.data_type == 'url.path.segment':
             # Viewing a channel on a server
             # Ex: https://discordapp.com/channels/427876741990711298/551531058039095296
@@ -122,6 +141,11 @@ def run(unfurl, node):
                         data_type='description', key=None, value=None, label='Attachment File Name',
                         parent_id=node.node_id, incoming_edge_config=discord_edge)
 
-            # Check if the node's value would correspond to a Snowflake with timestamp between 2015-02 and 2022-07
-            elif unfurl.check_if_int_between(node.value, 15000000000000000, 1000000000000000001):
+            # Check if the node's value would correspond to a Snowflake with a plausible timestamp
+            elif unfurl.check_if_int_between(node.value, min_reasonable_id, max_reasonable_id):
                 parse_discord_snowflake(unfurl, node)
+
+        # Snowflakes also show up outside URL paths (query values, JSON payloads in
+        # tokens, etc.); decode anything under a Discord domain that looks like one.
+        elif unfurl.check_if_int_between(node.value, min_reasonable_id, max_reasonable_id):
+            parse_discord_snowflake(unfurl, node)

--- a/unfurl/parsers/parse_dns.py
+++ b/unfurl/parsers/parse_dns.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 from dnslib import DNSRecord
-import base64
-import binascii
 import re
+from unfurl import utils
 
 dns_edge = {
     'color': {
@@ -48,12 +47,15 @@ DNS_MESSAGE_FIELDS = {
 
 def run(unfurl, node):
     if node.data_type == 'url.query.pair' and node.key == 'dns':
+        decoded_query = utils.try_urlsafe_b64_decode(node.value)
+        if decoded_query is None:
+            return
+
         try:
-            decoded_query = base64.urlsafe_b64decode(unfurl.add_b64_padding(node.value))
             dns_record = DNSRecord.parse(decoded_query)
 
         # Might not have been encoded DNS after all
-        except (TypeError, binascii.Error):
+        except Exception:
             return
 
         parsed_dns = repr(dns_record)

--- a/unfurl/parsers/parse_google.py
+++ b/unfurl/parsers/parse_google.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import base64
 import datetime
 
 import json
@@ -72,16 +71,14 @@ def parse_aqs(aqs: str) -> dict:
     return parsed
 
 
-def parse_ei(ei):
-    """Parse ei parameters from Google searches.
+def parse_ei(decoded):
+    """Parse (base64-decoded) ei parameters from Google searches.
 
     Based on work by:
       Adrian Leong (cheeky4n6monkey@gmail.com) -
         https://github.com/cheeky4n6monkey/4n6-scripts/blob/master/google-ei-time.py
       Kevin Jones - https://deedpolloffice.com/blog/articles/decoding-ei-parameter
     """
-
-    decoded = base64.urlsafe_b64decode(ei)
 
     # grab 1st 4 bytes and treat as LE unsigned int
     timestamp = struct.unpack('<i', decoded[0:4])[0]
@@ -282,16 +279,14 @@ def run(unfurl, node):
                         parent_id=node.node_id, incoming_edge_config=google_edge)
 
         elif node.key == 'ei':
-            if not re.fullmatch(utils.urlsafe_b64_re, node.value):
-                return
-            padded_value = unfurl.add_b64_padding(node.value)
-            if not padded_value:
+            decoded_ei = utils.try_urlsafe_b64_decode(node.value, min_length=8)
+            if decoded_ei is None:
                 return
 
             try:
-                parsed_ei = parse_ei(padded_value)
+                parsed_ei = parse_ei(decoded_ei)
             except Exception as e:
-                log.exception(f'Exception running parse_ei() on {padded_value}: {e}')
+                log.exception(f'Exception running parse_ei() on {node.value}: {e}')
                 return
 
             if not parsed_ei:
@@ -448,7 +443,9 @@ def run(unfurl, node):
 
         elif node.key == 'uule':
             # https://moz.com/ugc/geolocation-the-ultimate-tip-to-emulate-local-search
-            location_string = base64.b64decode(unfurl.add_b64_padding(node.value[10:]))
+            location_string = utils.try_standard_b64_decode(node.value[10:])
+            if location_string is None:
+                return
             unfurl.add_to_queue(
                 data_type='google.uule', key=None, value=location_string, label=location_string,
                 parent_id=node.node_id, incoming_edge_config=google_edge)

--- a/unfurl/parsers/parse_itsdangerous.py
+++ b/unfurl/parsers/parse_itsdangerous.py
@@ -1,0 +1,137 @@
+# Copyright 2026 Ryan Benson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import zlib
+from unfurl import utils
+
+import logging
+log = logging.getLogger(__name__)
+
+itsdangerous_edge = {
+    'color': {
+        'color': '#CC3333'
+    },
+    'title': 'itsdangerous Signed Token',
+    'label': '🔏'
+}
+
+# itsdangerous versions before 2.0 stored timestamps as seconds since
+# 2011-01-01 (the library's release year) rather than the Unix epoch.
+ITSDANGEROUS_LEGACY_EPOCH = 1293840000
+
+# Tokens from itsdangerous's URLSafeTimedSerializer (used by Flask and many
+# other Python web apps for email verification links, password resets,
+# session cookies, etc.) look similar to JWTs but have a different structure:
+#   base64(payload) . base64(big-endian timestamp) . base64(HMAC signature)
+# If the payload was zlib-compressed, the whole token gets a leading '.'.
+# The timestamp segment is a minimal big-endian integer (4 bytes / 6 base64
+# characters for current dates), which is what distinguishes these from JWTs
+# (whose middle segment is a JSON payload, far longer than 8 characters).
+itsdangerous_token_re = re.compile(
+    r'(?P<compressed>\.)?'
+    r'(?P<payload>[A-Za-z0-9_\-]{4,}={0,2})\.'
+    r'(?P<timestamp>[A-Za-z0-9_\-]{4,8})\.'
+    r'(?P<signature>[A-Za-z0-9_\-]{27,86}={0,2})')
+
+
+def run(unfurl, node):
+
+    if not isinstance(node.value, str):
+        return
+
+    # Don't re-run on the component nodes this parser creates.
+    if node.data_type.startswith('itsdangerous'):
+        return
+
+    m = itsdangerous_token_re.fullmatch(node.value)
+    if not m:
+        return
+
+    timestamp_bytes = utils.try_urlsafe_b64_decode(m['timestamp'])
+    signature_bytes = utils.try_urlsafe_b64_decode(m['signature'])
+    payload_bytes = utils.try_urlsafe_b64_decode(m['payload'])
+    if not (timestamp_bytes and signature_bytes and payload_bytes):
+        return
+
+    # HMAC digests run from 16 bytes (MD5) to 64 (SHA-512); itsdangerous
+    # defaults to SHA-1 (20 bytes), and SHA-256 (32) is also common.
+    if not 16 <= len(signature_bytes) <= 64:
+        return
+
+    # The timestamp is the strongest false-positive gate: the decoded bytes,
+    # read as a big-endian integer, must be a plausible signing time. Values
+    # that don't fit either the modern (Unix epoch) or legacy (2011 epoch)
+    # interpretation mean this isn't an itsdangerous token; bail out.
+    timestamp_int = int.from_bytes(timestamp_bytes, 'big')
+    plausible_range_start = ITSDANGEROUS_LEGACY_EPOCH
+    plausible_range_end = utils.create_epoch_seconds_timestamp(days_ahead=365)
+    legacy = False
+    if plausible_range_start <= timestamp_int < plausible_range_end:
+        epoch_seconds = timestamp_int
+    elif plausible_range_start <= timestamp_int + ITSDANGEROUS_LEGACY_EPOCH < plausible_range_end:
+        epoch_seconds = timestamp_int + ITSDANGEROUS_LEGACY_EPOCH
+        legacy = True
+    else:
+        return
+
+    if m['compressed']:
+        try:
+            payload_bytes = utils.safe_decompress(payload_bytes)
+        except (zlib.error, ValueError):
+            return
+
+    node.hover = 'This looks like a signed token from the Python <b>itsdangerous</b> library ' \
+                 '(used by Flask and other web frameworks for verification links, password ' \
+                 'resets, and session cookies). ' \
+                 '<a href="https://itsdangerous.palletsprojects.com/" target="_blank">[ref]</a>'
+
+    payload_hover = 'itsdangerous tokens have three parts: the payload, a timestamp, and a ' \
+                    'signature. The <b>payload</b> is the base64-encoded data that was signed'
+    if m['compressed']:
+        payload_hover += ', which was also zlib-compressed (indicated by the token\'s leading ".")'
+        if utils.is_printable_ascii(payload_bytes):
+            unfurl.add_to_queue(
+                data_type='string', key='Payload', value=payload_bytes.decode('ascii'),
+                hover=payload_hover, parent_id=node.node_id, incoming_edge_config=itsdangerous_edge)
+        else:
+            unfurl.add_to_queue(
+                data_type='bytes', key='Payload', value=payload_bytes,
+                hover=payload_hover, parent_id=node.node_id, incoming_edge_config=itsdangerous_edge)
+    else:
+        # Queue the still-encoded payload as an explicit base64 node; the base64
+        # parser will decode it (bypassing its auto-detection heuristics) and
+        # downstream parsers (JSON, etc.) can continue from there.
+        unfurl.add_to_queue(
+            data_type='base64', key='Payload', value=m['payload'],
+            hover=payload_hover, parent_id=node.node_id, incoming_edge_config=itsdangerous_edge)
+
+    timestamp_hover = 'itsdangerous tokens have three parts: the payload, a timestamp, and a ' \
+                      'signature. The <b>timestamp</b> is when the token was signed, encoded ' \
+                      'as a base64 big-endian integer'
+    if legacy:
+        timestamp_hover += '. This token stores it as seconds since 2011-01-01 ' \
+                           '(itsdangerous versions before 2.0)'
+    unfurl.add_to_queue(
+        data_type='epoch-seconds', key='Timestamp', value=epoch_seconds,
+        label=f'Signing Timestamp: {epoch_seconds}',
+        hover=timestamp_hover, parent_id=node.node_id, incoming_edge_config=itsdangerous_edge)
+
+    unfurl.add_to_queue(
+        data_type='itsdangerous.signature', key='Signature', value=m['signature'],
+        label=f'HMAC Signature ({len(signature_bytes)} bytes)',
+        hover='itsdangerous tokens have three parts: the payload, a timestamp, and a '
+              'signature. The <b>signature</b> is an HMAC of the payload and timestamp; '
+              'the server verifies it with a secret key to detect tampering',
+        parent_id=node.node_id, incoming_edge_config=itsdangerous_edge)

--- a/unfurl/parsers/parse_protobuf.py
+++ b/unfurl/parsers/parse_protobuf.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import base64
 import json
 import logging
 import os
@@ -267,8 +266,6 @@ def run(unfurl, node):
     if node.data_type.startswith(('uuid', 'hash')):
         return False
 
-    urlsafe_b64_m = utils.urlsafe_b64_re.fullmatch(node.value)
-    standard_b64_m = utils.standard_b64_re.fullmatch(node.value)
     hex_m = utils.hex_re.fullmatch(node.value)
     # Updating to all letters/digits and forward slashes, to catch URL paths that may,
     # by some chance, validly decode as protobuf, but really aren't.
@@ -285,26 +282,17 @@ def run(unfurl, node):
     attempts = []
 
     if not (all_digits_m or all_letters_m):
-        # A valid b64 string is never length % 4 == 1 (hex is always even-length,
-        # so this guard only affects the base64 candidates).
-        b64_ok = len(node.value) % 4 != 1
         if hex_m:
             try:
                 attempts.append((bytes.fromhex(node.value), hex_proto_edge))
             except ValueError:
                 pass
-        elif urlsafe_b64_m and b64_ok:
-            try:
-                attempts.append(
-                    (base64.urlsafe_b64decode(unfurl.add_b64_padding(node.value)), b64_proto_edge))
-            except Exception:
-                pass
-        elif standard_b64_m and b64_ok:
-            try:
-                attempts.append(
-                    (base64.b64decode(unfurl.add_b64_padding(node.value)), b64_proto_edge))
-            except Exception:
-                pass
+        else:
+            b64_decoded = utils.try_urlsafe_b64_decode(node.value, min_length=8)
+            if b64_decoded is None:
+                b64_decoded = utils.try_standard_b64_decode(node.value, min_length=8)
+            if b64_decoded is not None:
+                attempts.append((b64_decoded, b64_proto_edge))
 
         b32_decoded = utils.try_base32_decode(node.value)
         if b32_decoded is not None:

--- a/unfurl/parsers/parse_twitter.py
+++ b/unfurl/parsers/parse_twitter.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import base64
 from unfurl import utils
 
 import logging
@@ -55,13 +54,11 @@ def parse_twitter_snowflake(unfurl, node, encoding_type='integer', on_twitter=Tr
     # So far, I've only observed this in file attachments (images) to tweets. This format
     # also has three extra bytes at the "end" (LSBs); I don't know their function.
     elif encoding_type == 'base64':
-        m = utils.urlsafe_b64_re.fullmatch(node.value)
-        if not m:
+        snowflake_bytes = utils.try_urlsafe_b64_decode(node.value, min_length=8)
+        if snowflake_bytes is None:
             return
 
         try:
-            padded_value = unfurl.add_b64_padding(node.value)
-            snowflake_bytes = base64.urlsafe_b64decode(padded_value)
             snowflake_int = int.from_bytes(snowflake_bytes, 'big')
             timestamp = (snowflake_int >> 46) + 1288834974657
             machine_id = (snowflake_int & 0x3FF000000000) >> 36

--- a/unfurl/tests/unit/test_itsdangerous.py
+++ b/unfurl/tests/unit/test_itsdangerous.py
@@ -1,0 +1,147 @@
+import base64
+import zlib
+
+from unfurl.core import Unfurl
+import unittest
+
+
+def _b64(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode().rstrip('=')
+
+
+def _make_token(payload: bytes, timestamp: int, sig_bytes: bytes = b'\x01' * 20, compress: bool = False) -> str:
+    prefix = ''
+    if compress:
+        payload = zlib.compress(payload)
+        prefix = '.'
+    ts_bytes = timestamp.to_bytes((timestamp.bit_length() + 7) // 8, 'big')
+    return f'{prefix}{_b64(payload)}.{_b64(ts_bytes)}.{_b64(sig_bytes)}'
+
+
+def _edge_labels(test):
+    labels = []
+    for node in test.nodes.values():
+        config = getattr(node, 'incoming_edge_config', None)
+        if config:
+            labels.append(config.get('label'))
+    return labels
+
+
+class TestItsDangerous(unittest.TestCase):
+
+    def test_discord_verify_token(self):
+        """ Test a real-world Discord email verification link, which contains an
+        itsdangerous token whose payload holds a user ID (Snowflake) and email."""
+
+        test = Unfurl()
+        test.add_to_queue(
+            data_type='url', key=None,
+            value='https://discord.com/verify#token=eyJpZCI6MTM4MjA4MTIyMzQ2MzE0MTQ2OCwiZW1haWwiOiJvY3RvYm9iMjNAZ21ha'
+                  'WwuY29tIn0.aEiJsA.YJXCGEC-sCDSwQAbMmF5NMsDFBg')
+        test.parse_queue()
+
+        node_values = [n.value for n in test.nodes.values()]
+
+        # The signing timestamp (2025-06-10 19:38:24 UTC) was decoded
+        self.assertIn(1749584304, node_values)
+
+        # The payload was base64-decoded to the JSON it contains
+        self.assertIn('{"id":1382081223463141468,"email":"octobob23@gmail.com"}', node_values)
+
+        # The JSON was parsed into its fields
+        self.assertIn('octobob23@gmail.com', node_values)
+
+        # The user ID was recognized as a Discord Snowflake and its timestamp extracted
+        self.assertIn(1749584241501, node_values)
+
+        # The signature node shows the HMAC size (SHA-1 -> 20 bytes)
+        node_labels = [getattr(n, 'label', None) for n in test.nodes.values()]
+        self.assertIn('HMAC Signature (20 bytes)', node_labels)
+
+    def test_modern_timestamp(self):
+        """ Test a manually-built token with a modern (Unix epoch) timestamp."""
+
+        token = _make_token(b'{"user": 123}', 1749584304)
+        test = Unfurl()
+        test.add_to_queue(data_type='url', key=None, value=token)
+        test.parse_queue()
+
+        node_values = [n.value for n in test.nodes.values()]
+        self.assertIn(1749584304, node_values)
+        self.assertIn('{"user": 123}', node_values)
+
+    def test_legacy_timestamp(self):
+        """ Test a token using the pre-2.0 itsdangerous epoch (2011-01-01); the
+        decoded value should be normalized to Unix epoch seconds."""
+
+        token = _make_token(b'{"user": 123}', 1749584304 - 1293840000)
+        test = Unfurl()
+        test.add_to_queue(data_type='url', key=None, value=token)
+        test.parse_queue()
+
+        node_values = [n.value for n in test.nodes.values()]
+        self.assertIn(1749584304, node_values)
+
+    def test_compressed_payload(self):
+        """ Test a token with a zlib-compressed payload (leading '.'); the payload
+        should be decompressed and its JSON parsed."""
+
+        token = _make_token(b'{"purpose": "test-compression-in-itsdangerous"}', 1749584304, compress=True)
+        test = Unfurl()
+        test.add_to_queue(data_type='url', key=None, value=token)
+        test.parse_queue()
+
+        node_values = [n.value for n in test.nodes.values()]
+        self.assertIn('{"purpose": "test-compression-in-itsdangerous"}', node_values)
+        self.assertIn('test-compression-in-itsdangerous', node_values)
+        self.assertIn(1749584304, node_values)
+
+    def test_sha256_signature(self):
+        """ Test a token signed with HMAC-SHA256 (32-byte signature)."""
+
+        token = _make_token(b'{"user": 123}', 1749584304, sig_bytes=b'\x02' * 32)
+        test = Unfurl()
+        test.add_to_queue(data_type='url', key=None, value=token)
+        test.parse_queue()
+
+        node_labels = [getattr(n, 'label', None) for n in test.nodes.values()]
+        self.assertIn('HMAC Signature (32 bytes)', node_labels)
+
+    def test_jwt_not_claimed(self):
+        """ A real JWT (long JSON middle segment) should be parsed as a JWT,
+        not an itsdangerous token."""
+
+        test = Unfurl()
+        test.add_to_queue(
+            data_type='url', key=None,
+            value='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0Ijox'
+                  'NTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c')
+        test.parse_queue()
+
+        labels = _edge_labels(test)
+        self.assertIn('JWT', labels)
+        self.assertNotIn('🔏', labels)
+
+    def test_implausible_timestamp_not_decoded(self):
+        """ A three-part string whose middle segment isn't a plausible timestamp
+        should not be treated as an itsdangerous token."""
+
+        # Middle segment decodes to 6 bytes -> far larger than any plausible epoch
+        test = Unfurl()
+        test.add_to_queue(data_type='url', key=None, value='eyJ1c2VyIjogMTIzfQ.zzzzzzzz.YJXCGEC-sCDSwQAbMmF5NMsDFBg')
+        test.parse_queue()
+
+        self.assertNotIn('🔏', _edge_labels(test))
+
+    def test_ordinary_dotted_string_not_decoded(self):
+        """ Dotted strings like filenames or hostnames should not fire the parser."""
+
+        test = Unfurl()
+        test.add_to_queue(data_type='url', key=None, value='some.file.name')
+        test.parse_queue()
+
+        self.assertNotIn('🔏', _edge_labels(test))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unfurl/utils.py
+++ b/unfurl/utils.py
@@ -20,7 +20,7 @@ import ipaddress
 import re
 import textwrap
 import zlib
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Union
 
 long_int_re = re.compile(r'\d{8,}')
@@ -84,6 +84,56 @@ def try_base32_decode(value):
         return None
 
 
+urlsafe_b64_charset_re = re.compile(r'[A-Za-z0-9_\-]+')
+standard_b64_charset_re = re.compile(r'[A-Za-z0-9+/]+')
+
+
+def _try_b64_decode(value, charset_re, decoder, min_length):
+    if not isinstance(value, str):
+        return None
+
+    unpadded = value.rstrip('=')
+
+    # min_length of 1 (the floor) still rejects empty/all-padding values.
+    if len(unpadded) < max(min_length, 1):
+        return None
+
+    if not charset_re.fullmatch(unpadded):
+        return None
+
+    # Base64 encodes 3 bytes into 4 characters, so a valid (unpadded) length
+    # mod 4 is never 1.
+    if len(unpadded) % 4 == 1:
+        return None
+
+    padded = unpadded + ('=' * (-len(unpadded) % 4))
+    try:
+        return decoder(padded)
+    except (binascii.Error, ValueError):
+        return None
+
+
+def try_urlsafe_b64_decode(value, min_length=1):
+    """Return base64url-decoded bytes for value, or None if it isn't decodable.
+
+    Pure decode mechanics (alphabet, length, and padding handling) shared by any
+    parser that needs to attempt a base64 decode, mirroring try_base32_decode.
+
+    min_length is the minimum length of the encoded string (excluding padding).
+    Callers auto-detecting base64 in arbitrary values should pass a higher gate
+    (the base64 parser uses 8) to limit false positives; callers whose
+    surrounding structure already identifies the value as base64 (e.g. a segment
+    of an itsdangerous token) can leave the default.
+    """
+    return _try_b64_decode(value, urlsafe_b64_charset_re, base64.urlsafe_b64decode, min_length)
+
+
+def try_standard_b64_decode(value, min_length=1):
+    """Return base64-decoded bytes for value (standard alphabet, using + and /),
+    or None if it isn't decodable. See try_urlsafe_b64_decode for min_length."""
+    return _try_b64_decode(value, standard_b64_charset_re, base64.b64decode, min_length)
+
+
 def parse_ip_address(potential_ip):
     if re.fullmatch(digits_re, potential_ip):
         potential_ip = int(potential_ip)
@@ -128,7 +178,8 @@ def create_epoch_seconds_timestamp(iso_timestamp: str | None = None, days_ahead:
     some number of days in the future. Optionally, an offset (in seconds) can be provided that will be subtracted
     from the return timestamp.
 
-    :param iso_timestamp: An ISO 8601-formatted timestamp string (ex: 2015-02-01T00:00:00)
+    :param iso_timestamp: An ISO 8601-formatted timestamp string (ex: 2015-02-01T00:00:00).
+        If it has no timezone, it is interpreted as UTC.
     :param days_ahead: Number of days ahead the timestamp should be created for (ex: 365)
     :param offset: The offset in seconds from the Unix epoch
     :return: An integer timestamp (in seconds)
@@ -139,7 +190,12 @@ def create_epoch_seconds_timestamp(iso_timestamp: str | None = None, days_ahead:
         timestamp = int(datetime.now().timestamp())
     # timestamp is a string; parse it to epoch seconds
     elif iso_timestamp:
-        timestamp = int(datetime.fromisoformat(iso_timestamp).timestamp())
+        parsed = datetime.fromisoformat(iso_timestamp)
+        if parsed.tzinfo is None:
+            # Interpret naive timestamps as UTC; .timestamp() would otherwise
+            # assume local time, shifting the result by the machine's UTC offset.
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        timestamp = int(parsed.timestamp())
     # Make the timestamp now + days_ahead
     elif not iso_timestamp and days_ahead:
         timestamp = int(datetime.now().timestamp()) + (days_ahead * 86400)


### PR DESCRIPTION
…r-ish to JWTs). Along the way, refactored a bunch of b64 decoding logic.


- [x] Tests pass
- [ ] Appropriate changes to README are included in PR